### PR TITLE
[sve2] Fix saturating rounding doubling multiply accumulate simulation

### DIFF
--- a/src/aarch64/simulator-aarch64.h
+++ b/src/aarch64/simulator-aarch64.h
@@ -2781,6 +2781,10 @@ class Simulator : public DecoderVisitor {
                                             uint64_t left,
                                             uint64_t right,
                                             int carry_in);
+  using vixl_uint128_t = std::pair<uint64_t, uint64_t>;
+  vixl_uint128_t Add128(vixl_uint128_t x, vixl_uint128_t y);
+  vixl_uint128_t Mul64(uint64_t x, uint64_t y);
+  vixl_uint128_t Neg128(vixl_uint128_t x);
   void LogicalHelper(const Instruction* instr, int64_t op2);
   void ConditionalCompareHelper(const Instruction* instr, int64_t op2);
   void LoadStoreHelper(const Instruction* instr,
@@ -3966,6 +3970,12 @@ class Simulator : public DecoderVisitor {
                            const LogicVRegister& src2,
                            bool round = true,
                            bool sub_op = false);
+  LogicVRegister sqrdmlash_d(VectorFormat vform,
+                             LogicVRegister dst,
+                             const LogicVRegister& src1,
+                             const LogicVRegister& src2,
+                             bool round = true,
+                             bool sub_op = false);
   LogicVRegister sqrdmlah(VectorFormat vform,
                           LogicVRegister dst,
                           const LogicVRegister& src1,

--- a/temp
+++ b/temp
@@ -1,0 +1,1 @@
+this is a testing file.

--- a/temp
+++ b/temp
@@ -1,1 +1,0 @@
-this is a testing file.

--- a/test/aarch64/test-assembler-sve-aarch64.cc
+++ b/test/aarch64/test-assembler-sve-aarch64.cc
@@ -19256,6 +19256,154 @@ TEST_SVE(sve2_sqrdcmlah) {
   }
 }
 
+TEST_SVE(sve2_sqrdmlah) {
+  uint16_t zn_inputs_h[] = {0x7ffe, 0x7ffd, 0x7ffd, 0x7ffd, 0x8000,
+                            0x7fff, 0x7ffe, 0x7ffe, 0x8001, 0x8000,
+                            0x7ffd, 0x7ffd, 0x7ffd, 0x5555, 0x5555,
+                            0x5555, 0x8000, 0x8000, 0xaaaa, 0x8001};
+
+  uint16_t zm_inputs_h[] = {0x7ffd, 0x7fff, 0x7ffe, 0x7ffd, 0x8001,
+                            0x7fff, 0x7fff, 0x7ffe, 0x8000, 0x8000,
+                            0xaaaa, 0x0001, 0x0001, 0xaaaa, 0xaaaa,
+                            0xcccc, 0x8000, 0x8000, 0x8000, 0x8001};
+
+  uint16_t za_inputs_h[] = {0x1010, 0x1010, 0x1010, 0x1010, 0x1010,
+                            0x1010, 0x1010, 0x1010, 0x8000, 0x8011,
+                            0x8006, 0xff7d, 0xfeff, 0xaabc, 0xaabb,
+                            0x9c72, 0x8000, 0x0000, 0x8000, 0xffff};
+
+  uint16_t zd_expected_h[] = {0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff,
+                              0x7fff, 0x7fff, 0x7fff, 0xffff, 0x0011,
+                              0x8000, 0xff7e, 0xff00, 0x8000, 0x8000,
+                              0x8000, 0x0000, 0x7fff, 0xd556, 0x7ffd};
+
+  uint32_t zn_inputs_s[] = {0x04000000,
+                            0x80000000,
+                            0x04000000,
+                            0x80000000,
+                            0x80000000,
+                            0x80000001,
+                            0x7fffffff,
+                            0x80000000,
+                            0x7ffffffe,
+                            0x7ffffffd,
+                            0x7ffffffd,
+                            0x7ffffffd};
+
+  uint32_t zm_inputs_s[] = {0x00000020,
+                            0x80000000,
+                            0x00000010,
+                            0x80000000,
+                            0x7fffffff,
+                            0x80000000,
+                            0x80000000,
+                            0x80000001,
+                            0x7ffffffd,
+                            0x7fffffff,
+                            0x7ffffffe,
+                            0x7ffffffd};
+
+  uint32_t za_inputs_s[] = {0x00000000,
+                            0x00000000,
+                            0x00000020,
+                            0x00108000,
+                            0x00000000,
+                            0x00000001,
+                            0x00000000,
+                            0x00000001,
+                            0x10101010,
+                            0x10101010,
+                            0x10101010,
+                            0x10101010};
+
+  uint32_t zd_expected_s[] = {0x00000001,
+                              0x7fffffff,
+                              0x00000021,
+                              0x7fffffff,
+                              0x80000001,
+                              0x7fffffff,
+                              0x80000001,
+                              0x7fffffff,
+                              0x7fffffff,
+                              0x7fffffff,
+                              0x7fffffff,
+                              0x7fffffff};
+
+  uint64_t zn_inputs_d[] = {0x0400000000000000, 0x8000000000000000,
+                            0x0400000000000000, 0x8000000000000000,
+                            0x8000000000000000, 0x8000000000000001,
+                            0x7fffffffffffffff, 0x8000000000000000,
+                            0x7ffffffffffffffe, 0x7ffffffffffffffd,
+                            0x7ffffffffffffffd, 0x7ffffffffffffffd,
+                            0xf1299accc9186169, 0xd529d2675ee9da21,
+                            0x1a10b5d60b92dcf9, 0xfb1d358e0e6455b1,
+                            0x8eb7721078bdc589, 0x4171509750ded141,
+                            0x8eb7721078bdc589, 0x4171509750ded141};
+
+  uint64_t zm_inputs_d[] = {0x0000000000000020, 0x8000000000000000,
+                            0x0000000000000010, 0x8000000000000000,
+                            0x7fffffffffffffff, 0x8000000000000000,
+                            0x8000000000000000, 0x8000000000000001,
+                            0x7ffffffffffffffd, 0x7fffffffffffffff,
+                            0x7ffffffffffffffe, 0x7ffffffffffffffd,
+                            0x30b940efe73f180e, 0x3bc1ff1e52a99b66,
+                            0x40de5c9793535a5e, 0x24752faf47bdddb6,
+                            0x162663016b07e5ae, 0x1de34b56f3d22006,
+                            0x8eb7721078bdc589, 0x4171509750ded141};
+
+  uint64_t za_inputs_d[] = {0x0000000000000000, 0x0000000000000000,
+                            0x0000000000000020, 0x0010108000000000,
+                            0x0000000000000000, 0x0000000000000001,
+                            0x0000000000000000, 0x0000000000000001,
+                            0x1010101010101010, 0x1010101010101010,
+                            0x1010101010101010, 0x1010101010101010,
+                            0xb18253371b2c2c77, 0xa70de31e6645eaef,
+                            0xda817198c0318487, 0x9fd9e6b8e04b42ff,
+                            0xced1f6b7119ab197, 0x01ae051a85509b0f,
+                            0x01a211e9352f7927, 0x7667b70a5b13749f};
+
+  uint64_t zd_expected_d[] = {0x0000000000000001, 0x7fffffffffffffff,
+                              0x0000000000000021, 0x7fffffffffffffff,
+                              0x8000000000000001, 0x7fffffffffffffff,
+                              0x8000000000000001, 0x7fffffffffffffff,
+                              0x7fffffffffffffff, 0x7fffffffffffffff,
+                              0x7fffffffffffffff, 0x7fffffffffffffff,
+                              0xabdc73dea0d72a35, 0x930e3dc877301966,
+                              0xe7b7145a059f8a9f, 0x9e75a4a9d10cf8af,
+                              0xbb378528642d2581, 0x10f5e6d693ffddf3,
+                              0x65e455a46adc091c, 0x7fffffffffffffff};
+
+  SVE_SETUP_WITH_FEATURES(CPUFeatures::kSVE, CPUFeatures::kSVE2);
+  START();
+
+  InsrHelper(&masm, z0.VnH(), zn_inputs_h);
+  InsrHelper(&masm, z1.VnH(), zm_inputs_h);
+  InsrHelper(&masm, z2.VnH(), za_inputs_h);
+
+  __ Sqrdmlah(z2.VnH(), z2.VnH(), z0.VnH(), z1.VnH());
+
+  InsrHelper(&masm, z3.VnS(), zn_inputs_s);
+  InsrHelper(&masm, z4.VnS(), zm_inputs_s);
+  InsrHelper(&masm, z5.VnS(), za_inputs_s);
+
+  __ Sqrdmlah(z5.VnS(), z5.VnS(), z3.VnS(), z4.VnS());
+
+  InsrHelper(&masm, z6.VnD(), zn_inputs_d);
+  InsrHelper(&masm, z7.VnD(), zm_inputs_d);
+  InsrHelper(&masm, z8.VnD(), za_inputs_d);
+
+  __ Sqrdmlah(z8.VnD(), z8.VnD(), z6.VnD(), z7.VnD());
+
+  END();
+
+  if (CAN_RUN()) {
+    RUN();
+    ASSERT_EQUAL_SVE(zd_expected_h, z2.VnH());
+    ASSERT_EQUAL_SVE(zd_expected_s, z5.VnS());
+    ASSERT_EQUAL_SVE(zd_expected_d, z8.VnD());
+  }
+}
+
 TEST_SVE(sve2_cmla) {
   int32_t zn_inputs_s[] = {-2, -4, -6, -8, 2, 4, 6, 8};
   int32_t zm_inputs_s[] = {-2, -4, -6, -8, 2, 4, 6, 8};

--- a/test/aarch64/test-simulator-sve2-aarch64.cc
+++ b/test/aarch64/test-simulator-sve2-aarch64.cc
@@ -2046,85 +2046,85 @@ TEST_SVE(sve2_saturating_multiply_add_high_vector) {
   {
     ExactAssemblyScope scope(&masm, 40 * kInstructionSize);
     __ dci(0x44d9721a);  // sqrdmlah z26.d, z16.d, z25.d
-    // vl128 state = 0xe7f26fd2
+    // vl128 state = 0xc0474f3f
     __ dci(0x44dd761b);  // sqrdmlsh z27.d, z16.d, z29.d
-    // vl128 state = 0x627ffb65
+    // vl128 state = 0x102712ac
     __ dci(0x44d4760b);  // sqrdmlsh z11.d, z16.d, z20.d
-    // vl128 state = 0x727ac13a
+    // vl128 state = 0xe8666aa6
     __ dci(0x44947709);  // sqrdmlsh z9.s, z24.s, z20.s
-    // vl128 state = 0x47045ddf
+    // vl128 state = 0xdd18f643
     __ dci(0x4494770b);  // sqrdmlsh z11.s, z24.s, z20.s
-    // vl128 state = 0xbd00a91d
+    // vl128 state = 0xac4a4d4c
     __ dci(0x44d4773b);  // sqrdmlsh z27.d, z25.d, z20.d
-    // vl128 state = 0x399e7643
+    // vl128 state = 0x1a5447d4
     __ dci(0x44dc7639);  // sqrdmlsh z25.d, z17.d, z28.d
-    // vl128 state = 0x81b1ebaf
+    // vl128 state = 0xf547ac30
     __ dci(0x44dc763b);  // sqrdmlsh z27.d, z17.d, z28.d
-    // vl128 state = 0xff9c1896
+    // vl128 state = 0xb42d177a
     __ dci(0x44d4743f);  // sqrdmlsh z31.d, z1.d, z20.d
-    // vl128 state = 0x13e84bd0
+    // vl128 state = 0xd0da2c6b
     __ dci(0x449c742f);  // sqrdmlsh z15.s, z1.s, z28.s
-    // vl128 state = 0x717eee33
+    // vl128 state = 0xb24c8988
     __ dci(0x449c7487);  // sqrdmlsh z7.s, z4.s, z28.s
-    // vl128 state = 0x5d55ba17
+    // vl128 state = 0x9e67ddac
     __ dci(0x449c7485);  // sqrdmlsh z5.s, z4.s, z28.s
-    // vl128 state = 0x1a595359
+    // vl128 state = 0xd96b34e2
     __ dci(0x448e7481);  // sqrdmlsh z1.s, z4.s, z14.s
-    // vl128 state = 0x42eb77bc
+    // vl128 state = 0x81d91007
     __ dci(0x448e7480);  // sqrdmlsh z0.s, z4.s, z14.s
-    // vl128 state = 0x532dc129
+    // vl128 state = 0x901fa692
     __ dci(0x449c7488);  // sqrdmlsh z8.s, z4.s, z28.s
-    // vl128 state = 0x2dee895d
+    // vl128 state = 0xeedceee6
     __ dci(0x441c758a);  // sqrdmlsh z10.b, z12.b, z28.b
-    // vl128 state = 0x4ef6b432
+    // vl128 state = 0x8dc4d389
     __ dci(0x441475ae);  // sqrdmlsh z14.b, z13.b, z20.b
-    // vl128 state = 0x72437e89
+    // vl128 state = 0xb1711932
     __ dci(0x440075ac);  // sqrdmlsh z12.b, z13.b, z0.b
-    // vl128 state = 0x4f9e9633
+    // vl128 state = 0x8cacf188
     __ dci(0x440171bc);  // sqrdmlah z28.b, z13.b, z1.b
-    // vl128 state = 0x5fb9f8f4
+    // vl128 state = 0x9c8b9f4f
     __ dci(0x440171b8);  // sqrdmlah z24.b, z13.b, z1.b
-    // vl128 state = 0x951cd941
+    // vl128 state = 0x562ebefa
     __ dci(0x441971b9);  // sqrdmlah z25.b, z13.b, z25.b
-    // vl128 state = 0x29e34291
+    // vl128 state = 0x1ef60d31
     __ dci(0x440970bb);  // sqrdmlah z27.b, z5.b, z9.b
-    // vl128 state = 0x3b65ce2d
+    // vl128 state = 0x69bd18ee
     __ dci(0x441870ba);  // sqrdmlah z26.b, z5.b, z24.b
-    // vl128 state = 0x5390fc4e
+    // vl128 state = 0x525b1f84
     __ dci(0x441270b8);  // sqrdmlah z24.b, z5.b, z18.b
-    // vl128 state = 0x3db64e12
+    // vl128 state = 0x3c7dadd8
     __ dci(0x44927090);  // sqrdmlah z16.s, z4.s, z18.s
-    // vl128 state = 0x26a4e6ad
+    // vl128 state = 0x276f0567
     __ dci(0x44937292);  // sqrdmlah z18.s, z20.s, z19.s
-    // vl128 state = 0x6ec4687e
+    // vl128 state = 0x6f0f8bb4
     __ dci(0x4491721a);  // sqrdmlah z26.s, z16.s, z17.s
-    // vl128 state = 0x98640c48
-    __ dci(0x44907318);  // sqrdmlah z24.s, z24.s, z16.s
-    // vl128 state = 0x71e464cd
-    __ dci(0x4490737c);  // sqrdmlah z28.s, z27.s, z16.s
-    // vl128 state = 0x72b30439
-    __ dci(0x4488736c);  // sqrdmlah z12.s, z27.s, z8.s
-    // vl128 state = 0xb0004b01
-    __ dci(0x44817364);  // sqrdmlah z4.s, z27.s, z1.s
-    // vl128 state = 0xedd8d96e
-    __ dci(0x44c37365);  // sqrdmlah z5.d, z27.d, z3.d
-    // vl128 state = 0xb2ce3f95
-    __ dci(0x44c373d5);  // sqrdmlah z21.d, z30.d, z3.d
-    // vl128 state = 0x1b27c597
-    __ dci(0x44c373dd);  // sqrdmlah z29.d, z30.d, z3.d
-    // vl128 state = 0x459d64db
-    __ dci(0x444377df);  // sqrdmlsh z31.h, z30.h, z3.h
-    // vl128 state = 0x0a86a0bb
-    __ dci(0x444277fb);  // sqrdmlsh z27.h, z31.h, z2.h
-    // vl128 state = 0x0a7b442d
-    __ dci(0x440275eb);  // sqrdmlsh z11.b, z15.b, z2.b
-    // vl128 state = 0x47d1f4d8
-    __ dci(0x440276ea);  // sqrdmlsh z10.b, z23.b, z2.b
-    // vl128 state = 0x18ade1e2
-    __ dci(0x440276eb);  // sqrdmlsh z11.b, z23.b, z2.b
-    // vl128 state = 0x34498c16
-    __ dci(0x440677ef);  // sqrdmlsh z15.b, z31.b, z6.b
-    // vl128 state = 0x76b6ce44
+    // vl128 state = 0x28eb737a
+    __ dci(0x44d3721b);  // sqrdmlah z27.d, z16.d, z19.d
+    // vl128 state = 0xa3bd1133
+    __ dci(0x44d372ab);  // sqrdmlah z11.d, z21.d, z19.d
+    // vl128 state = 0x6e81e8fd
+    __ dci(0x44d372a3);  // sqrdmlah z3.d, z21.d, z19.d
+    // vl128 state = 0x55730750
+    __ dci(0x445376a1);  // sqrdmlsh z1.h, z21.h, z19.h
+    // vl128 state = 0x7c7afd6d
+    __ dci(0x44527685);  // sqrdmlsh z5.h, z20.h, z18.h
+    // vl128 state = 0x1c9dc1a1
+    __ dci(0x44127495);  // sqrdmlsh z21.b, z4.b, z18.b
+    // vl128 state = 0xf2e07e92
+    __ dci(0x44127794);  // sqrdmlsh z20.b, z28.b, z18.b
+    // vl128 state = 0xc5a2e589
+    __ dci(0x44527695);  // sqrdmlsh z21.h, z20.h, z18.h
+    // vl128 state = 0x417df395
+    __ dci(0x445274dd);  // sqrdmlsh z29.h, z6.h, z18.h
+    // vl128 state = 0x2e223308
+    __ dci(0x445774df);  // sqrdmlsh z31.h, z6.h, z23.h
+    // vl128 state = 0x99047839
+    __ dci(0x445775fe);  // sqrdmlsh z30.h, z15.h, z23.h
+    // vl128 state = 0x34a4be39
+    __ dci(0x445175ff);  // sqrdmlsh z31.h, z15.h, z17.h
+    // vl128 state = 0x714b9d66
+    __ dci(0x44517557);  // sqrdmlsh z23.h, z10.h, z17.h
+    // vl128 state = 0x2aa51ff4
   }
 
   uint32_t state;
@@ -2136,22 +2136,22 @@ TEST_SVE(sve2_saturating_multiply_add_high_vector) {
   if (CAN_RUN()) {
     RUN();
     uint32_t expected_hashes[] = {
-        0x76b6ce44,
-        0x9aed065f,
-        0x2dc82c4b,
-        0x39dff095,
-        0x67905033,
-        0x4f1a64f8,
-        0x19b9f1d2,
-        0x365818b7,
-        0xd6d4d404,
-        0x955d5613,
-        0x8d01f38f,
-        0x045e51c7,
-        0x40946c78,
-        0x7ce16d49,
-        0x328f8df9,
-        0xb7f6df30,
+        0x2aa51ff4,
+        0xde163ba0,
+        0x8b237661,
+        0x30086cf2,
+        0xabf248f0,
+        0xcc183608,
+        0xa4103141,
+        0x521ebe39,
+        0xd746470e,
+        0x141a51a4,
+        0x695a47fd,
+        0x0a74d701,
+        0xd14bae63,
+        0xf967aadb,
+        0xdaed8896,
+        0x7ba556cb,
     };
     ASSERT_EQUAL_64(expected_hashes[core.GetSVELaneCount(kQRegSize) - 1], x0);
   }


### PR DESCRIPTION
The existing logic doesn't support d-sized lane operation.
We add Neg128, Add128 and Mul64 function for this fix.