### PR TITLE
fix: do not force HARDFLOAT when using soft fp

### DIFF
--- a/src/aarch32/instructions-aarch32.h
+++ b/src/aarch32/instructions-aarch32.h
@@ -38,7 +38,7 @@ extern "C" {
 #include "utils-vixl.h"
 #include "aarch32/constants-aarch32.h"
 
-#ifdef __arm__
+#if defined(__arm__) && !defined(__SOFTFP__)
 #define HARDFLOAT __attribute__((noinline, pcs("aapcs-vfp")))
 #else
 #define HARDFLOAT __attribute__((noinline))


### PR DESCRIPTION
Fixes compilation on Debian armel, see https://buildd.debian.org/status/fetch.php?pkg=vixl&arch=armel&ver=5.1.0-1&stamp=1637517716&raw=0

Previously, Vixl would force hard float on all arm CPUs, by checking only for `__arm__`. This would cause GCC to throw an internal error when compiling with `-mfloat-abi=soft`. See also this example on Compiler Explorer: https://compiler-explorer.com/z/zsn5vaMna