### PR TITLE
assembler-aarch64: Prevent -Wshadow warning

### DIFF
--- a/src/aarch64/assembler-aarch64.h
+++ b/src/aarch64/assembler-aarch64.h
@@ -7081,11 +7081,11 @@ class Assembler : public vixl::internal::AssemblerBase {
   static Instr ImmTestBranchBit(unsigned bit_pos) {
     VIXL_ASSERT(IsUint6(bit_pos));
     // Subtract five from the shift offset, as we need bit 5 from bit_pos.
-    unsigned b5 = bit_pos << (ImmTestBranchBit5_offset - 5);
-    unsigned b40 = bit_pos << ImmTestBranchBit40_offset;
-    b5 &= ImmTestBranchBit5_mask;
-    b40 &= ImmTestBranchBit40_mask;
-    return b5 | b40;
+    unsigned bit5 = bit_pos << (ImmTestBranchBit5_offset - 5);
+    unsigned bit40 = bit_pos << ImmTestBranchBit40_offset;
+    bit5 &= ImmTestBranchBit5_mask;
+    bit40 &= ImmTestBranchBit40_mask;
+    return bit5 | bit40;
   }
 
   // Data Processing encoding.


### PR DESCRIPTION
Prevents a stray variable shadowing warning from appearing in projects including vixl with -Wshadow enabled.

`operands-aarch64.h` defines a bunch of vector register convenience operands via the `DEFINE_VREGISTERS` preprocessor define, which results in the `b5` convenience operand being shadowed by the local `b5` variable.
