### PR TITLE
Fix bitwise-instead-of-logical warning in assembler-aarch64.cc

### DIFF
--- a/src/aarch64/assembler-aarch64.cc
+++ b/src/aarch64/assembler-aarch64.cc
@@ -2735,7 +2735,7 @@ void Assembler::fmov(const VRegister& vd, float imm) {
     Emit(FMOV_s_imm | Rd(vd) | ImmFP32(imm));
   } else {
     VIXL_ASSERT(CPUHas(CPUFeatures::kNEON));
-    VIXL_ASSERT(vd.Is2S() | vd.Is4S());
+    VIXL_ASSERT(vd.Is2S() || vd.Is4S());
     Instr op = NEONModifiedImmediate_MOVI;
     Instr q = vd.Is4S() ? NEON_Q : 0;
     uint32_t encoded_imm = FP32ToImm8(imm);


### PR DESCRIPTION
Clang 14 (current trunk) warns about the use of a bitwise operation on booleans.