### PR TITLE
Check string is non-zero length in examples

### DIFF
--- a/examples/aarch64/custom-disassembler.cc
+++ b/examples/aarch64/custom-disassembler.cc
@@ -113,7 +113,8 @@ void CustomDisassembler::Visit(Metadata* metadata, const Instruction* instr) {
 
   // Match the forms for 32/64-bit add/subtract with shift, with optional flag
   // setting.
-  if (std::regex_match(form,
+  if (!form.empty() &&
+      std::regex_match(form,
                        std::regex("(?:add|sub)s?_(?:32|64)_addsub_shift"))) {
     if (instr->GetRd() == 10) {
       AppendToOutput(" // add/sub to x10");

--- a/examples/aarch64/non-const-visitor.cc
+++ b/examples/aarch64/non-const-visitor.cc
@@ -41,7 +41,8 @@ void SwitchAddSubRegisterSources::Visit(Metadata* metadata,
 
   // Match the forms for 32/64-bit add/subtract with shift, with optional flag
   // setting.
-  if (std::regex_match(form,
+  if (!form.empty() &&
+      std::regex_match(form,
                        std::regex("(?:add|sub)s?_(?:32|64)_addsub_shift"))) {
     int rn = instr->GetRn();
     int rm = instr->GetRm();


### PR DESCRIPTION
Check the form string is non-zero length. This is an attempt to satisfy the
linter used in the Mac CI.