### PR TITLE
Disable linter on regex calls

### DIFF
--- a/examples/aarch64/custom-disassembler.cc
+++ b/examples/aarch64/custom-disassembler.cc
@@ -113,7 +113,7 @@ void CustomDisassembler::Visit(Metadata* metadata, const Instruction* instr) {
 
   // Match the forms for 32/64-bit add/subtract with shift, with optional flag
   // setting.
-  if (std::regex_match(form,
+  if (std::regex_match(form,  // NOLINT: avoid clang-tidy-4.0 errors.
                        std::regex("(?:add|sub)s?_(?:32|64)_addsub_shift"))) {
     if (instr->GetRd() == 10) {
       AppendToOutput(" // add/sub to x10");

--- a/examples/aarch64/non-const-visitor.cc
+++ b/examples/aarch64/non-const-visitor.cc
@@ -41,7 +41,7 @@ void SwitchAddSubRegisterSources::Visit(Metadata* metadata,
 
   // Match the forms for 32/64-bit add/subtract with shift, with optional flag
   // setting.
-  if (std::regex_match(form,
+  if (std::regex_match(form,  // NOLINT: avoid clang-tidy-4.0 errors.
                        std::regex("(?:add|sub)s?_(?:32|64)_addsub_shift"))) {
     int rn = instr->GetRn();
     int rm = instr->GetRm();


### PR DESCRIPTION
Disable linter for calls to regex_match, as this causes failures for the version
of clang-tidy used in the Mac CI.