### PR TITLE
aarch64: Allow testing for the presence of FEAT_AFP

### DIFF
--- a/src/aarch64/cpu-aarch64.cc
+++ b/src/aarch64/cpu-aarch64.cc
@@ -294,7 +294,7 @@ CPUFeatures CPU::InferCPUFeaturesFromOS(
        // Bits 48+
        CPUFeatures::kRNG,
        CPUFeatures::kBTI,
-       CPUFeatures::kNone,   // "MTE"
+       CPUFeatures::kMTE,
        CPUFeatures::kNone,  // "ECV"
        CPUFeatures::kAFP,
        CPUFeatures::kNone};  // "RPRES"
@@ -308,6 +308,10 @@ CPUFeatures CPU::InferCPUFeaturesFromOS(
   VIXL_STATIC_ASSERT(ArrayLength(kFeatureBits) < 64);
   for (size_t i = 0; i < ArrayLength(kFeatureBits); i++) {
     if (hwcap & (UINT64_C(1) << i)) features.Combine(kFeatureBits[i]);
+  }
+  // MTE support from HWCAP2 signifies FEAT_MTE1 and FEAT_MTE2 support
+  if (features.Has(CPUFeatures::kMTE)) {
+    features.Combine(CPUFeatures::kMTEInstructions);
   }
 #endif  // VIXL_USE_LINUX_HWCAP
 

--- a/src/aarch64/cpu-aarch64.cc
+++ b/src/aarch64/cpu-aarch64.cc
@@ -79,6 +79,7 @@ const IDRegister::Field AA64ISAR1::kDGH(48);
 const IDRegister::Field AA64ISAR1::kI8MM(52);
 
 const IDRegister::Field AA64MMFR1::kLO(16);
+const IDRegister::Field AA64MMFR1::kAFP(44);
 
 const IDRegister::Field AA64MMFR2::kAT(32);
 
@@ -176,6 +177,7 @@ CPUFeatures AA64ISAR1::GetCPUFeatures() const {
 CPUFeatures AA64MMFR1::GetCPUFeatures() const {
   CPUFeatures f;
   if (Get(kLO) >= 1) f.Combine(CPUFeatures::kLORegions);
+  if (Get(kAFP) >= 1) f.Combine(CPUFeatures::kAFP);
   return f;
 }
 
@@ -291,7 +293,11 @@ CPUFeatures CPU::InferCPUFeaturesFromOS(
        CPUFeatures::kDGH,
        // Bits 48+
        CPUFeatures::kRNG,
-       CPUFeatures::kBTI};
+       CPUFeatures::kBTI,
+       CPUFeatures::kNone,   // "MTE"
+       CPUFeatures::kNone,  // "ECV"
+       CPUFeatures::kAFP,
+       CPUFeatures::kNone};  // "RPRES"
 
   uint64_t hwcap_low32 = getauxval(AT_HWCAP);
   uint64_t hwcap_high32 = getauxval(AT_HWCAP2);

--- a/src/aarch64/cpu-aarch64.h
+++ b/src/aarch64/cpu-aarch64.h
@@ -168,6 +168,7 @@ class AA64MMFR1 : public IDRegister {
 
  private:
   static const Field kLO;
+  static const Field kAFP;
 };
 
 class AA64MMFR2 : public IDRegister {

--- a/src/cpu-features.h
+++ b/src/cpu-features.h
@@ -177,7 +177,9 @@ namespace vixl {
   V(kSVESHA3,             "SVE SHA3",               "svesha3")                 \
   V(kSVEBitPerm,          "SVE BitPerm",            "svebitperm")              \
   V(kSVEAES,              "SVE AES",                "sveaes")                  \
-  V(kSVEPmull128,         "SVE Pmull128",           "svepmull")
+  V(kSVEPmull128,         "SVE Pmull128",           "svepmull")                \
+  /* Alternate floating-point behavior                                      */ \
+  V(kAFP,                 "AFP",                    "afp")
 // clang-format on
 
 


### PR DESCRIPTION
Allows querying for the existence of FEAT_AFP (alternate floating-point behavior).

While we're in the same area, we can also fill in detection for the existing MTE feature bits