### PR TITLE
aarch64: Allow testing for the presence of FEAT_ECV and FEAT_RPRES

### DIFF
--- a/src/aarch64/cpu-aarch64.cc
+++ b/src/aarch64/cpu-aarch64.cc
@@ -78,6 +78,8 @@ const IDRegister::Field AA64ISAR1::kBF16(44);
 const IDRegister::Field AA64ISAR1::kDGH(48);
 const IDRegister::Field AA64ISAR1::kI8MM(52);
 
+const IDRegister::Field AA64ISAR2::kRPRES(4);
+
 const IDRegister::Field AA64MMFR0::kECV(60);
 
 const IDRegister::Field AA64MMFR1::kLO(16);
@@ -173,6 +175,12 @@ CPUFeatures AA64ISAR1::GetCPUFeatures() const {
   if (Get(kGPA) >= 1) {
     f.Combine(CPUFeatures::kPAuthGeneric, CPUFeatures::kPAuthGenericQARMA);
   }
+  return f;
+}
+
+CPUFeatures AA64ISAR2::GetCPUFeatures() const {
+  CPUFeatures f;
+  if (Get(kRPRES) >= 1) f.Combine(CPUFeatures::kRPRES);
   return f;
 }
 
@@ -305,7 +313,7 @@ CPUFeatures CPU::InferCPUFeaturesFromOS(
        CPUFeatures::kMTE,
        CPUFeatures::kECV,
        CPUFeatures::kAFP,
-       CPUFeatures::kNone};  // "RPRES"
+       CPUFeatures::kRPRES};
 
   uint64_t hwcap_low32 = getauxval(AT_HWCAP);
   uint64_t hwcap_high32 = getauxval(AT_HWCAP2);

--- a/src/aarch64/cpu-aarch64.cc
+++ b/src/aarch64/cpu-aarch64.cc
@@ -78,6 +78,8 @@ const IDRegister::Field AA64ISAR1::kBF16(44);
 const IDRegister::Field AA64ISAR1::kDGH(48);
 const IDRegister::Field AA64ISAR1::kI8MM(52);
 
+const IDRegister::Field AA64MMFR0::kECV(60);
+
 const IDRegister::Field AA64MMFR1::kLO(16);
 const IDRegister::Field AA64MMFR1::kAFP(44);
 
@@ -171,6 +173,12 @@ CPUFeatures AA64ISAR1::GetCPUFeatures() const {
   if (Get(kGPA) >= 1) {
     f.Combine(CPUFeatures::kPAuthGeneric, CPUFeatures::kPAuthGenericQARMA);
   }
+  return f;
+}
+
+CPUFeatures AA64MMFR0::GetCPUFeatures() const {
+  CPUFeatures f;
+  if (Get(kECV) >= 1) f.Combine(CPUFeatures::kECV);
   return f;
 }
 
@@ -295,7 +303,7 @@ CPUFeatures CPU::InferCPUFeaturesFromOS(
        CPUFeatures::kRNG,
        CPUFeatures::kBTI,
        CPUFeatures::kMTE,
-       CPUFeatures::kNone,  // "ECV"
+       CPUFeatures::kECV,
        CPUFeatures::kAFP,
        CPUFeatures::kNone};  // "RPRES"
 

--- a/src/aarch64/cpu-aarch64.h
+++ b/src/aarch64/cpu-aarch64.h
@@ -160,6 +160,16 @@ class AA64ISAR1 : public IDRegister {
   static const Field kI8MM;
 };
 
+class AA64MMFR0 : public IDRegister {
+ public:
+  explicit AA64MMFR0(uint64_t value) : IDRegister(value) {}
+
+  CPUFeatures GetCPUFeatures() const;
+
+ private:
+  static const Field kECV;
+};
+
 class AA64MMFR1 : public IDRegister {
  public:
   explicit AA64MMFR1(uint64_t value) : IDRegister(value) {}
@@ -261,6 +271,7 @@ class CPU {
   V(AA64PFR1, "ID_AA64PFR1_EL1")                                              \
   V(AA64ISAR0, "ID_AA64ISAR0_EL1")                                            \
   V(AA64ISAR1, "ID_AA64ISAR1_EL1")                                            \
+  V(AA64MMFR0, "ID_AA64MMFR0_EL1")                                            \
   V(AA64MMFR1, "ID_AA64MMFR1_EL1")                                            \
   /* These registers are RES0 in the baseline Arm8.0. We can always safely */ \
   /* read them, but some compilers don't accept the symbolic names. */        \

--- a/src/aarch64/cpu-aarch64.h
+++ b/src/aarch64/cpu-aarch64.h
@@ -160,6 +160,16 @@ class AA64ISAR1 : public IDRegister {
   static const Field kI8MM;
 };
 
+class AA64ISAR2 : public IDRegister {
+ public:
+  explicit AA64ISAR2(uint64_t value) : IDRegister(value) {}
+
+  CPUFeatures GetCPUFeatures() const;
+
+ private:
+  static const Field kRPRES;
+};
+
 class AA64MMFR0 : public IDRegister {
  public:
   explicit AA64MMFR0(uint64_t value) : IDRegister(value) {}
@@ -275,6 +285,7 @@ class CPU {
   V(AA64MMFR1, "ID_AA64MMFR1_EL1")                                            \
   /* These registers are RES0 in the baseline Arm8.0. We can always safely */ \
   /* read them, but some compilers don't accept the symbolic names. */        \
+  V(AA64ISAR2, "S3_0_C0_C6_2")                                                \
   V(AA64MMFR2, "S3_0_C0_C7_2")                                                \
   V(AA64ZFR0, "S3_0_C0_C4_4")
 

--- a/src/cpu-features.h
+++ b/src/cpu-features.h
@@ -181,7 +181,9 @@ namespace vixl {
   /* Alternate floating-point behavior                                      */ \
   V(kAFP,                 "AFP",                    "afp")                     \
   /* Enhanced Counter Virtualization                                        */ \
-  V(kECV,                 "ECV",                    "ecv")
+  V(kECV,                 "ECV",                    "ecv")                     \
+  /* Increased precision of Reciprocal Estimate and Square Root Estimate    */ \
+  V(kRPRES,               "RPRES",                  "rpres")
 // clang-format on
 
 

--- a/src/cpu-features.h
+++ b/src/cpu-features.h
@@ -179,7 +179,9 @@ namespace vixl {
   V(kSVEAES,              "SVE AES",                "sveaes")                  \
   V(kSVEPmull128,         "SVE Pmull128",           "svepmull")                \
   /* Alternate floating-point behavior                                      */ \
-  V(kAFP,                 "AFP",                    "afp")
+  V(kAFP,                 "AFP",                    "afp")                     \
+  /* Enhanced Counter Virtualization                                        */ \
+  V(kECV,                 "ECV",                    "ecv")
 // clang-format on
 
 


### PR DESCRIPTION
Fills out the remaining unimplemented handling of defined hwcap bits by allowing checking for FEAT_ECV (Enhanced Counter Virtualization), and FEAT_RPRES (Extended precision for Reciprocal Square Root Estimate and Reciprocal Estimate).

Now all currently defined hwcap bits are handled