### PR TITLE
aarch64: Remove invalid assert in GetCacheType

### DIFF
--- a/src/aarch64/cpu-aarch64.cc
+++ b/src/aarch64/cpu-aarch64.cc
@@ -393,7 +393,6 @@ uint32_t CPU::GetCacheType() {
   // Copy the content of the cache type register to a core register.
   __asm__ __volatile__("mrs %[ctr], ctr_el0"  // NOLINT(runtime/references)
                        : [ctr] "=r"(cache_type_register));
-  VIXL_ASSERT(IsUint32(cache_type_register));
   return static_cast<uint32_t>(cache_type_register);
 #else
   // This will lead to a cache with 1 byte long lines, which is fine since


### PR DESCRIPTION
With MTE introduced this assert is no longer valid.
bits [37:32] are now defined as TminLine.
Now that MTE hardware is shipping this assert is causing crashes.