### PR TITLE
A prototype to support memory metadata in the Simulator.

### DIFF
--- a/src/aarch64/cpu-aarch64.cc
+++ b/src/aarch64/cpu-aarch64.cc
@@ -29,6 +29,8 @@
 #define VIXL_USE_LINUX_HWCAP 1
 #endif
 
+#include <sys/mman.h>
+
 #include "../utils-vixl.h"
 
 #include "cpu-aarch64.h"
@@ -506,6 +508,65 @@ void CPU::EnsureIAndDCacheCoherency(void *address, size_t length) {
   USE(address, length);
 #endif
 }
+
+
+// Below functions creating/removing a mapping with memory protection
+// for both native and simulated execution environment.
+// Note that the protection flags for the Simulator are passed through the
+// features argument.
+void *CPU::Mmap(void *address,
+                size_t length,
+                int prot,
+                int flags,
+                int fd,
+                off_t offset,
+                Simulator *simulator,
+                CPUFeatures features) {
+  uint64_t address2 = reinterpret_cast<uint64_t>(
+      mmap(address, length, prot, flags, fd, offset));
+
+#ifdef VIXL_INCLUDE_SIMULATOR_AARCH64
+  VIXL_ASSERT(simulator != nullptr);
+
+  if (features.Has(CPUFeatures::kMTE)) {
+    // If runing on the simulator, the returning address of `mmap` isn't tagged.
+    // Geneate a random tag.
+    int tag = static_cast<int>(simulator->GenerateRandomTag());
+    simulator->SetGranuleTag(address2, tag, length);
+    address2 = simulator->GetAddressWithAllocationTag(address2, tag);
+  }
+#else
+  VIXL_ASSERT(simulator == nullptr);
+#endif
+
+  return reinterpret_cast<void *>(address2);
+}
+
+
+int CPU::Munmap(void *address,
+                size_t length,
+                Simulator *simulator,
+                CPUFeatures features) {
+#ifdef VIXL_INCLUDE_SIMULATOR_AARCH64
+  VIXL_ASSERT(simulator != nullptr);
+
+  if (features.Has(CPUFeatures::kMTE)) {
+    // Untag the address since `munmap` doesn't recognize the memory tagging
+    // managed by the Simulator.
+    address = AddressUntag(address);
+    size_t count =
+        simulator->CleanGranuleTag(reinterpret_cast<char *>(address), length);
+    size_t expected =
+        length / kMTETagGranuleInBytes + (length % kMTETagGranuleInBytes != 0);
+    VIXL_CHECK(count == expected);
+  }
+#else
+  VIXL_ASSERT(simulator == nullptr);
+#endif
+
+  return munmap(address, length);
+}
+
 
 }  // namespace aarch64
 }  // namespace vixl

--- a/src/aarch64/cpu-aarch64.h
+++ b/src/aarch64/cpu-aarch64.h
@@ -31,6 +31,7 @@
 #include "../globals-vixl.h"
 
 #include "instructions-aarch64.h"
+#include "simulator-aarch64.h"
 
 #ifndef VIXL_INCLUDE_TARGET_AARCH64
 // The supporting .cc file is only compiled when the A64 target is selected.
@@ -228,6 +229,20 @@ class CPU {
 
   // Query the SVE vector length. This requires CPUFeatures::kSVE.
   static int ReadSVEVectorLengthInBits();
+
+  static void *Mmap(void *address,
+                    size_t length,
+                    int prot,
+                    int flags,
+                    int fd,
+                    off_t offset,
+                    Simulator *simulator = nullptr,
+                    CPUFeatures features = CPUFeatures::None());
+
+  static int Munmap(void *address,
+                    size_t length,
+                    Simulator *simulator = nullptr,
+                    CPUFeatures features = CPUFeatures::None());
 
   // Handle tagged pointers.
   template <typename T>

--- a/src/aarch64/instructions-aarch64.h
+++ b/src/aarch64/instructions-aarch64.h
@@ -142,6 +142,7 @@ const unsigned kPRegMaxSizeInBytes = kPRegMaxSize / 8;
 const unsigned kPRegMaxSizeInBytesLog2 = kPRegMaxSizeLog2 - 3;
 
 const unsigned kMTETagGranuleInBytes = 16;
+const unsigned kMTETagGranuleInBytesLog2 = 4;
 const unsigned kMTETagWidth = 4;
 
 // Make these moved float constants backwards compatible

--- a/src/aarch64/logic-aarch64.cc
+++ b/src/aarch64/logic-aarch64.cc
@@ -167,6 +167,21 @@ SimFloat16 Simulator::UFixedToFloat16(uint64_t src,
 }
 
 
+uint64_t Simulator::GenerateRandomTag(uint16_t exclude) {
+  uint64_t rtag = nrand48(rand_state_) >> 28;
+  VIXL_ASSERT(IsUint4(rtag));
+
+  if (exclude == 0) {
+    exclude = nrand48(rand_state_) >> 27;
+  }
+
+  // TODO: implement this to better match the specification, which calls for a
+  // true random mode, and a pseudo-random mode with state (EL1.TAG) modified by
+  // PRNG.
+  return ChooseNonExcludedTag(rtag, 0, exclude);
+}
+
+
 void Simulator::ld1(VectorFormat vform, LogicVRegister dst, uint64_t addr) {
   dst.ClearForWrite(vform);
   for (int i = 0; i < LaneCountFromFormat(vform); i++) {

--- a/src/aarch64/simulator-constants-aarch64.h
+++ b/src/aarch64/simulator-constants-aarch64.h
@@ -56,6 +56,8 @@ enum DebugHltOpcode {
   kDisableCPUFeaturesOpcode,
   kSaveCPUFeaturesOpcode,
   kRestoreCPUFeaturesOpcode,
+  kMTEActive,
+  kMTEInactive,
   // Aliases.
   kDebugHltFirstOpcode = kUnreachableOpcode,
   kDebugHltLastOpcode = kLogOpcode

--- a/test/aarch64/test-assembler-aarch64.h
+++ b/test/aarch64/test-assembler-aarch64.h
@@ -132,6 +132,12 @@ namespace aarch64 {
     SimulationCPUFeaturesScope cpu(&masm, kInfrastructureCPUFeatures);        \
     __ PushCalleeSavedRegisters();                                            \
   }                                                                           \
+  /* The infrastructure code hasn't been covered at the moment, e.g. */       \
+  /* prologue/epilogue. Suppress tagging mis-match exception before this      \
+   * point. */                                                                \
+  if (masm.GetCPUFeatures()->Has(CPUFeatures::kMTE)) {                        \
+    __ Hlt(DebugHltOpcode::kMTEActive);                                       \
+  }                                                                           \
   {                                                                           \
     int trace_parameters = 0;                                                 \
     if (Test::trace_reg()) trace_parameters |= LOG_STATE;                     \
@@ -151,6 +157,9 @@ namespace aarch64 {
   /* Avoid unused-variable warnings in case a test never calls RUN(). */ \
   USE(offset_before_infrastructure_end);                                 \
   __ Trace(LOG_ALL, TRACE_DISABLE);                                      \
+  if (masm.GetCPUFeatures()->Has(CPUFeatures::kMTE)) {                   \
+    __ Hlt(DebugHltOpcode::kMTEInactive);                                \
+  }                                                                      \
   {                                                                      \
     SimulationCPUFeaturesScope cpu(&masm, kInfrastructureCPUFeatures);   \
     core.Dump(&masm);                                                    \

--- a/test/aarch64/test-metadata-aarch64.cc
+++ b/test/aarch64/test-metadata-aarch64.cc
@@ -1,0 +1,148 @@
+// Copyright 2022, VIXL authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//   * Neither the name of ARM Limited nor the names of its contributors may be
+//     used to endorse or promote products derived from this software without
+//     specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "test-runner.h"
+#include "test-utils.h"
+#include "aarch64/cpu-aarch64.h"
+#include "aarch64/test-utils-aarch64.h"
+
+#include "aarch64/cpu-aarch64.h"
+#include "aarch64/disasm-aarch64.h"
+#include "aarch64/macro-assembler-aarch64.h"
+#include "aarch64/simulator-aarch64.h"
+#include "test-assembler-aarch64.h"
+
+namespace vixl {
+namespace aarch64 {
+
+TEST(test_metadata_mte) {
+  CPUFeatures features(CPUFeatures::kMTE);
+  SETUP_WITH_FEATURES(features);
+
+  size_t data_size = 320;
+  uintptr_t tagged_address =
+      reinterpret_cast<uintptr_t>(CPU::Mmap(NULL,
+                                            data_size,
+                                            PROT_READ | PROT_WRITE,
+                                            MAP_PRIVATE | MAP_ANONYMOUS,
+                                            -1,
+                                            0,
+                                            &simulator,
+                                            features));
+
+  START();
+
+  Register tagged_heap_ptr = x20;
+  __ Mov(tagged_heap_ptr, reinterpret_cast<uintptr_t>(tagged_address));
+  for (int i = 0; i < 10; i++) {
+    __ Ldr(w0, MemOperand(tagged_heap_ptr, i * 32));
+    __ Str(w0, MemOperand(tagged_heap_ptr, i * 32));
+  }
+  __ Ldr(x2, MemOperand(tagged_heap_ptr, 8));
+  __ Ldrb(w3, MemOperand(tagged_heap_ptr, 1));
+  __ Ldrh(w4, MemOperand(tagged_heap_ptr, 67));
+
+  __ Addg(x21, tagged_heap_ptr, 16, 2);
+
+  END();
+
+  if (CAN_RUN()) {
+    RUN();
+  }
+
+  VIXL_CHECK(CPU::Munmap(reinterpret_cast<char*>(tagged_address),
+                         data_size,
+                         &simulator,
+                         features) == 0);
+}
+
+#ifdef VIXL_NEGATIVE_TESTING
+TEST(test_metadata_mte_neg) {
+  CPUFeatures features(CPUFeatures::kMTE);
+  SETUP_WITH_FEATURES(features);
+  size_t data_size = 320;
+  uintptr_t tagged_address =
+      reinterpret_cast<uintptr_t>(CPU::Mmap(NULL,
+                                            data_size,
+                                            PROT_READ | PROT_WRITE,
+                                            MAP_PRIVATE | MAP_ANONYMOUS,
+                                            -1,
+                                            0,
+                                            &simulator,
+                                            features));
+
+  START();
+
+  Register tagged_heap_ptr = x20;
+  __ Mov(tagged_heap_ptr, reinterpret_cast<uintptr_t>(tagged_address));
+  __ Addg(x21, tagged_heap_ptr, 16, 2);
+
+  // The memory tag has been changed and becomes invalid.
+  __ Ldr(w0, MemOperand(x21));
+  __ Str(w0, MemOperand(x21));
+
+  // Out-of-bound access error.
+  __ Ldr(w0, MemOperand(tagged_heap_ptr, 320));
+  __ Str(w0, MemOperand(tagged_heap_ptr, 336));
+  __ Ldr(w0, MemOperand(tagged_heap_ptr, -8));
+  __ Str(w0, MemOperand(tagged_heap_ptr, -16));
+
+  uintptr_t tagged_address_2 =
+      reinterpret_cast<uintptr_t>(CPU::Mmap(NULL,
+                                            data_size,
+                                            PROT_READ | PROT_WRITE,
+                                            MAP_PRIVATE | MAP_ANONYMOUS,
+                                            -1,
+                                            0,
+                                            &simulator,
+                                            features));
+
+  __ Mov(x22, reinterpret_cast<uintptr_t>(tagged_address_2));
+  VIXL_CHECK(CPU::Munmap(reinterpret_cast<char*>(tagged_address_2),
+                         data_size,
+                         &simulator,
+                         features) == 0);
+
+  // Use-after-free error.
+  __ Ldr(w0, MemOperand(x22));
+
+  END();
+
+  if (CAN_RUN()) {
+    MUST_FAIL_WITH_MESSAGE(RUN(), "Tag mismatch.");
+  }
+
+  VIXL_CHECK(CPU::Munmap(reinterpret_cast<char*>(tagged_address),
+                         data_size,
+                         &simulator,
+                         features) == 0);
+}
+#endif  // VIXL_NEGATIVE_TESTING
+}
+}  // namespace vixl::aarch64


### PR DESCRIPTION
MTE is the first-supported target. Add an example to demonstrate how it works.