### PR TITLE
[mte] Add cache maintenance operations

### DIFF
--- a/src/aarch64/constants-aarch64.h
+++ b/src/aarch64/constants-aarch64.h
@@ -523,7 +523,15 @@ enum DataCacheOp {
   CVAP = CacheOpEncoder<3, 7, 12, 1>::value,
   CVADP = CacheOpEncoder<3, 7, 13, 1>::value,
   CIVAC = CacheOpEncoder<3, 7, 14, 1>::value,
-  ZVA = CacheOpEncoder<3, 7, 4, 1>::value
+  ZVA = CacheOpEncoder<3, 7, 4, 1>::value,
+  GVA = CacheOpEncoder<3, 7, 4, 3>::value,
+  GZVA = CacheOpEncoder<3, 7, 4, 4>::value,
+  CGVAC = CacheOpEncoder<3, 7, 10, 3>::value,
+  CGDVAC = CacheOpEncoder<3, 7, 10, 5>::value,
+  CGVAP = CacheOpEncoder<3, 7, 12, 3>::value,
+  CGDVAP = CacheOpEncoder<3, 7, 12, 5>::value,
+  CIGVAC = CacheOpEncoder<3, 7, 14, 3>::value,
+  CIGDVAC = CacheOpEncoder<3, 7, 14, 5>::value
 };
 
 // Some SVE instructions support a predicate constraint pattern. This is

--- a/src/aarch64/cpu-features-auditor-aarch64.cc
+++ b/src/aarch64/cpu-features-auditor-aarch64.cc
@@ -1305,6 +1305,16 @@ void CPUFeaturesAuditor::VisitSystem(const Instruction* instr) {
   } else if (instr->Mask(SystemSysMask) == SYS) {
     switch (instr->GetSysOp()) {
       // DC instruction variants.
+      case CGVAC:
+      case CGDVAC:
+      case CGVAP:
+      case CGDVAP:
+      case CIGVAC:
+      case CIGDVAC:
+      case GVA:
+      case GZVA:
+        scope.Record(CPUFeatures::kMTE);
+        break;
       case CVAP:
         scope.Record(CPUFeatures::kDCPoP);
         break;
@@ -1315,6 +1325,7 @@ void CPUFeaturesAuditor::VisitSystem(const Instruction* instr) {
       case CVAC:
       case CVAU:
       case CIVAC:
+      case ZVA:
         // No special CPU features.
         break;
     }

--- a/src/aarch64/disasm-aarch64.cc
+++ b/src/aarch64/disasm-aarch64.cc
@@ -2750,40 +2750,43 @@ void Disassembler::VisitSystem(const Instruction *instr) {
     case Hash("dsb_bo_barriers"):
       form = "'M";
       break;
-    case Hash("sys_cr_systeminstrs"):
+    case Hash("sys_cr_systeminstrs"): {
       mnemonic = "dc";
       suffix = ", 'Xt";
-      switch (instr->GetSysOp()) {
-        case IVAU:
+
+      const std::map<uint32_t, const char *> dcop = {
+          {IVAU, "ivau"},
+          {CVAC, "cvac"},
+          {CVAU, "cvau"},
+          {CVAP, "cvap"},
+          {CVADP, "cvadp"},
+          {CIVAC, "civac"},
+          {ZVA, "zva"},
+          {GVA, "gva"},
+          {GZVA, "gzva"},
+          {CGVAC, "cgvac"},
+          {CGDVAC, "cgdvac"},
+          {CGVAP, "cgvap"},
+          {CGDVAP, "cgdvap"},
+          {CIGVAC, "cigvac"},
+          {CIGDVAC, "cigdvac"},
+      };
+
+      uint32_t sysop = instr->GetSysOp();
+      if (dcop.count(sysop)) {
+        if (sysop == IVAU) {
           mnemonic = "ic";
-          form = "ivau";
-          break;
-        case CVAC:
-          form = "cvac";
-          break;
-        case CVAU:
-          form = "cvau";
-          break;
-        case CVAP:
-          form = "cvap";
-          break;
-        case CVADP:
-          form = "cvadp";
-          break;
-        case CIVAC:
-          form = "civac";
-          break;
-        case ZVA:
-          form = "zva";
-          break;
-        default:
-          mnemonic = "sys";
-          form = "'G1, 'Kn, 'Km, 'G2";
-          if (instr->GetRt() == 31) {
-            suffix = NULL;
-          }
-          break;
+        }
+        form = dcop.at(sysop);
+      } else {
+        mnemonic = "sys";
+        form = "'G1, 'Kn, 'Km, 'G2";
+        if (instr->GetRt() == 31) {
+          suffix = NULL;
+        }
+        break;
       }
+    }
   }
   Format(instr, mnemonic, form, suffix);
 }

--- a/src/aarch64/simulator-aarch64.cc
+++ b/src/aarch64/simulator-aarch64.cc
@@ -6461,12 +6461,22 @@ void Simulator::SysOp_W(int op, int64_t val) {
     case CVAU:
     case CVAP:
     case CVADP:
-    case CIVAC: {
+    case CIVAC:
+    case CGVAC:
+    case CGDVAC:
+    case CGVAP:
+    case CGDVAP:
+    case CIGVAC:
+    case CIGDVAC: {
       // Perform a placeholder memory access to ensure that we have read access
-      // to the specified address.
+      // to the specified address. The read access does not require a tag match,
+      // so temporarily disable MTE.
+      bool mte_enabled = MetaDataDepot::MetaDataMTE::IsActive();
+      MetaDataDepot::MetaDataMTE::SetActive(false);
       volatile uint8_t y = MemRead<uint8_t>(val);
+      MetaDataDepot::MetaDataMTE::SetActive(mte_enabled);
       USE(y);
-      // TODO: Implement "case ZVA:".
+      // TODO: Implement ZVA, GVA, GZVA.
       break;
     }
     default:

--- a/test/aarch64/test-assembler-aarch64.cc
+++ b/test/aarch64/test-assembler-aarch64.cc
@@ -12507,6 +12507,26 @@ TEST(system_dccvadp) {
   }
 }
 
+TEST(system_dc_mte) {
+  SETUP_WITH_FEATURES(CPUFeatures::kMTE);
+  const char* msg = "DC MTE test!";
+  uintptr_t msg_addr = reinterpret_cast<uintptr_t>(msg);
+
+  START();
+  __ Mov(x20, msg_addr);
+  __ Dc(CGVAC, x20);
+  __ Dc(CGDVAC, x20);
+  __ Dc(CGVAP, x20);
+  __ Dc(CGDVAP, x20);
+  __ Dc(CIGVAC, x20);
+  __ Dc(CIGDVAC, x20);
+  END();
+
+  if (CAN_RUN()) {
+    RUN();
+    ASSERT_EQUAL_64(msg_addr, x20);
+  }
+}
 
 // We currently disable tests for CRC32 instructions when running natively.
 // Support for this family of instruction is optional, and so native platforms

--- a/test/aarch64/test-disasm-aarch64.cc
+++ b/test/aarch64/test-disasm-aarch64.cc
@@ -2694,6 +2694,20 @@ TEST(system_dc) {
   CLEANUP();
 }
 
+TEST(system_dc_mte) {
+  SETUP();
+
+  COMPARE(dc(GVA, x0), "dc gva, x0");
+  COMPARE(dc(GZVA, x1), "dc gzva, x1");
+  COMPARE(dc(CGVAC, x2), "dc cgvac, x2");
+  COMPARE(dc(CGDVAC, x3), "dc cgdvac, x3");
+  COMPARE(dc(CGVAP, x3), "dc cgvap, x3");
+  COMPARE(dc(CGDVAP, x3), "dc cgdvap, x3");
+  COMPARE(dc(CIGVAC, x4), "dc cigvac, x4");
+  COMPARE(dc(CIGDVAC, x4), "dc cigdvac, x4");
+
+  CLEANUP();
+}
 
 TEST(system_nop) {
   SETUP();


### PR DESCRIPTION
Add the EL0 tag-related data cache maintenance operations provided by MTE. Also,
tidy up the other CMOs into a map.