### PR TITLE
logic-aarch64: Fix simulator register clearing bug in extractnarrow

### DIFF
--- a/src/aarch64/logic-aarch64.cc
+++ b/src/aarch64/logic-aarch64.cc
@@ -2217,7 +2217,6 @@ LogicVRegister Simulator::extractnarrow(VectorFormat dstform,
     offset = LaneCountFromFormat(dstform) / 2;
   } else {
     offset = 0;
-    dst.ClearForWrite(dstform);
   }
 
   for (int i = 0; i < LaneCountFromFormat(srcform); i++) {
@@ -2256,6 +2255,10 @@ LogicVRegister Simulator::extractnarrow(VectorFormat dstform,
     } else {
       dst.SetUint(dstform, offset + i, result);
     }
+  }
+
+  if (!upperhalf) {
+    dst.ClearForWrite(dstform);
   }
   return dst;
 }


### PR DESCRIPTION
Fixes a case in the simulator where the upper lanes of the register will be cleared before the narrowing operation occurs.

Normally, clearing beforehand works... as long as your source and destination are always different. When the source and destination are the same this trounces data that the narrowing operation needs to use.

Now all the narrowing operations should work correctly if the source and destination are the same.