### PR TITLE
Regression test for XTN fix

### DIFF
--- a/test/aarch64/test-assembler-neon-aarch64.cc
+++ b/test/aarch64/test-assembler-neon-aarch64.cc
@@ -5977,6 +5977,44 @@ TEST(neon_2regmisc_sqxtun) {
   }
 }
 
+TEST(neon_2regmisc_xtn_regression_test) {
+  SETUP_WITH_FEATURES(CPUFeatures::kNEON);
+
+  START();
+
+  __ Movi(v0.V2D(), 0x5555555555555555, 0x5555555555555555);
+  __ Movi(v1.V2D(), 0xaaaaaaaaaaaaaaaa, 0xaaaaaaaaaaaaaaaa);
+  __ Movi(v2.V2D(), 0x5555555555555555, 0x5555555555555555);
+  __ Movi(v3.V2D(), 0xaaaaaaaaaaaaaaaa, 0xaaaaaaaaaaaaaaaa);
+  __ Movi(v4.V2D(), 0x5555555555555555, 0x5555555555555555);
+  __ Movi(v5.V2D(), 0xaaaaaaaaaaaaaaaa, 0xaaaaaaaaaaaaaaaa);
+  __ Movi(v6.V2D(), 0x5555555555555555, 0x5555555555555555);
+  __ Movi(v7.V2D(), 0xaaaaaaaaaaaaaaaa, 0xaaaaaaaaaaaaaaaa);
+
+  __ Xtn(v0.V2S(), v0.V2D());
+  __ Xtn2(v1.V4S(), v1.V2D());
+  __ Sqxtn(v2.V2S(), v2.V2D());
+  __ Sqxtn2(v3.V4S(), v3.V2D());
+  __ Uqxtn(v4.V2S(), v4.V2D());
+  __ Uqxtn2(v5.V4S(), v5.V2D());
+  __ Sqxtun(v6.V2S(), v6.V2D());
+  __ Sqxtun2(v7.V4S(), v7.V2D());
+
+  END();
+
+  if (CAN_RUN()) {
+    RUN();
+    ASSERT_EQUAL_128(0x0000000000000000, 0x5555555555555555, q0);
+    ASSERT_EQUAL_128(0xaaaaaaaaaaaaaaaa, 0xaaaaaaaaaaaaaaaa, q1);
+    ASSERT_EQUAL_128(0x0000000000000000, 0x7fffffff7fffffff, q2);
+    ASSERT_EQUAL_128(0x8000000080000000, 0xaaaaaaaaaaaaaaaa, q3);
+    ASSERT_EQUAL_128(0x0000000000000000, 0xffffffffffffffff, q4);
+    ASSERT_EQUAL_128(0xffffffffffffffff, 0xaaaaaaaaaaaaaaaa, q5);
+    ASSERT_EQUAL_128(0x0000000000000000, 0xffffffffffffffff, q6);
+    ASSERT_EQUAL_128(0x0000000000000000, 0xaaaaaaaaaaaaaaaa, q7);
+  }
+}
+
 TEST(neon_3same_and) {
   SETUP_WITH_FEATURES(CPUFeatures::kNEON);
 


### PR DESCRIPTION
Add a simple regression test for xtn and related instructions. The test fails for revisions before 1ba324d89f7d3bf8471a2aa42d8c90a9b8aad341