### PR TITLE
instructions-aarch64: Handle destructive EXT in CanTakeSVEMovprfx

### DIFF
--- a/src/aarch64/instructions-aarch64.cc
+++ b/src/aarch64/instructions-aarch64.cc
@@ -198,6 +198,7 @@ bool Instruction::CanTakeSVEMovprfx(uint32_t form_hash,
     case "decd_z_zs"_h:
     case "dech_z_zs"_h:
     case "decw_z_zs"_h:
+    case "ext_z_zi_des"_h:
     case "faddp_z_p_zz"_h:
     case "fmaxnmp_z_p_zz"_h:
     case "fmaxp_z_p_zz"_h:


### PR DESCRIPTION
The ARM architecture manual states that a destructive SVE EXT instructions might be preceded by a MOVPRFX instruction, and that this is allowed, but that:

1. The MOVPRFX instruction must be unpredicated
2. The MOVPRFX instruction must specify the same destination as the EXT instruction.
3. The destination register cannot refer to any other source operand in the EXT instruction.

This allows MOVPRFX to work with destructive variants of EXT instead of hitting an assertion in the simulator.