### PR TITLE
aarch64: Allow testing for the presence of SVE FEAT_EBF16

### DIFF
--- a/src/aarch64/cpu-aarch64.cc
+++ b/src/aarch64/cpu-aarch64.cc
@@ -227,6 +227,7 @@ CPUFeatures AA64ZFR0::GetCPUFeatures() const {
   if (Get(kSM4) >= 1) f.Combine(CPUFeatures::kSVESM4);
   if (Get(kSHA3) >= 1) f.Combine(CPUFeatures::kSVESHA3);
   if (Get(kBF16) >= 1) f.Combine(CPUFeatures::kSVEBF16);
+  if (Get(kBF16) >= 2) f.Combine(CPUFeatures::kSVE_EBF16);
   if (Get(kBitPerm) >= 1) f.Combine(CPUFeatures::kSVEBitPerm);
   if (Get(kAES) >= 1) f.Combine(CPUFeatures::kSVEAES);
   if (Get(kAES) >= 2) f.Combine(CPUFeatures::kSVEPmull128);
@@ -355,7 +356,8 @@ CPUFeatures CPU::InferCPUFeaturesFromOS(
        CPUFeatures::kSMEfa64,
        CPUFeatures::kWFXT,
        // Bits 32-39
-       CPUFeatures::kEBF16};
+       CPUFeatures::kEBF16,
+       CPUFeatures::kSVE_EBF16};
   VIXL_STATIC_ASSERT(ArrayLength(kFeatureBitsHigh) < 64);
 
   auto combine_features = [&features](uint64_t hwcap,

--- a/src/cpu-features.h
+++ b/src/cpu-features.h
@@ -199,7 +199,8 @@ namespace vixl {
   /* WFET and WFIT instruction support                                      */ \
   V(kWFXT,                "WFXT",                   "wfxt")                    \
   /* Extended BFloat16 instructions                                         */ \
-  V(kEBF16,               "EBF16",                  "ebf16")
+  V(kEBF16,               "EBF16",                  "ebf16")                   \
+  V(kSVE_EBF16,           "EBF16 (SVE)",            "sveebf16")
 // clang-format on
 
 


### PR DESCRIPTION
Allows testing the new hwcap for determining SVE support for extended BFloat16 behavior on Linux systems.