### PR TITLE
Fix incorrect instruction mappings

### DIFF
--- a/src/aarch64/decoder-visitor-map-aarch64.h
+++ b/src/aarch64/decoder-visitor-map-aarch64.h
@@ -2593,7 +2593,6 @@
       {"dsb_bo_barriers"_h, &VISITORCLASS::VisitSystem},                       \
       {"hint_hm_hints"_h, &VISITORCLASS::VisitSystem},                         \
       {"mrs_rs_systemmove"_h, &VISITORCLASS::VisitSystem},                     \
-      {"msr_si_pstate"_h, &VISITORCLASS::VisitSystem},                         \
       {"msr_sr_systemmove"_h, &VISITORCLASS::VisitSystem},                     \
       {"psb_hc_hints"_h, &VISITORCLASS::VisitSystem},                          \
       {"sb_only_barriers"_h, &VISITORCLASS::VisitSystem},                      \

--- a/src/aarch64/decoder-visitor-map-aarch64.h
+++ b/src/aarch64/decoder-visitor-map-aarch64.h
@@ -2643,7 +2643,7 @@
       {"bfdot_asimdelem_e"_h, &VISITORCLASS::VisitUnimplemented},              \
       {"bfdot_asimdsame2_d"_h, &VISITORCLASS::VisitUnimplemented},             \
       {"bfmlal_asimdelem_f"_h, &VISITORCLASS::VisitUnimplemented},             \
-      {"bfmlal_asimdsame2_f_"_h, &VISITORCLASS::VisitUnimplemented},           \
+      {"bfmlal_asimdsame2_f"_h, &VISITORCLASS::VisitUnimplemented},           \
       {"bfmmla_asimdsame2_e"_h, &VISITORCLASS::VisitUnimplemented},            \
       {"dsb_bon_barriers"_h, &VISITORCLASS::VisitUnimplemented},               \
       {"eor3_vvv16_crypto4"_h, &VISITORCLASS::VisitUnimplemented},             \
@@ -2689,13 +2689,13 @@
       {"xar_vvv2_crypto3_imm6"_h, &VISITORCLASS::VisitUnimplemented},          \
       {"bfcvt_z_p_z_s2bf"_h, &VISITORCLASS::VisitUnimplemented},               \
       {"bfcvtnt_z_p_z_s2bf"_h, &VISITORCLASS::VisitUnimplemented},             \
-      {"bfdot_z_zzz_"_h, &VISITORCLASS::VisitUnimplemented},                   \
-      {"bfdot_z_zzzi_"_h, &VISITORCLASS::VisitUnimplemented},                  \
-      {"bfmlalb_z_zzz_"_h, &VISITORCLASS::VisitUnimplemented},                 \
-      {"bfmlalb_z_zzzi_"_h, &VISITORCLASS::VisitUnimplemented},                \
-      {"bfmlalt_z_zzz_"_h, &VISITORCLASS::VisitUnimplemented},                 \
-      {"bfmlalt_z_zzzi_"_h, &VISITORCLASS::VisitUnimplemented},                \
-      {"bfmmla_z_zzz_"_h, &VISITORCLASS::VisitUnimplemented}, {                \
+      {"bfdot_z_zzz"_h, &VISITORCLASS::VisitUnimplemented},                   \
+      {"bfdot_z_zzzi"_h, &VISITORCLASS::VisitUnimplemented},                  \
+      {"bfmlalb_z_zzz"_h, &VISITORCLASS::VisitUnimplemented},                 \
+      {"bfmlalb_z_zzzi"_h, &VISITORCLASS::VisitUnimplemented},                \
+      {"bfmlalt_z_zzz"_h, &VISITORCLASS::VisitUnimplemented},                 \
+      {"bfmlalt_z_zzzi"_h, &VISITORCLASS::VisitUnimplemented},                \
+      {"bfmmla_z_zzz"_h, &VISITORCLASS::VisitUnimplemented}, {                \
     "unallocated"_h, &VISITORCLASS::VisitUnallocated                           \
   }
 

--- a/src/aarch64/disasm-aarch64.cc
+++ b/src/aarch64/disasm-aarch64.cc
@@ -1995,7 +1995,6 @@ void Disassembler::VisitSystem(const Instruction *instr) {
     case "mrs_rs_systemmove"_h:
       form = "'Xt, 'IY";
       break;
-    case "msr_si_pstate"_h:
     case "msr_sr_systemmove"_h:
       form = "'IY, 'Xt";
       break;


### PR DESCRIPTION
- 22ad42d9ff1fe30c865e8b6de2f4ea36b699d221 removes references to the no longer used `msr_si_pstate` instruction.
- e774feff850f1837603009f08900880ae353c565 removes extra `_` characters in some instruction names.