### PR TITLE
Restore FPCR after modifying it in a test.

### DIFF
--- a/test/aarch64/test-assembler-aarch64.cc
+++ b/test/aarch64/test-assembler-aarch64.cc
@@ -7131,6 +7131,9 @@ TEST(system_msr) {
   __ Cinc(x7, x7, hs);  // C
   __ Cinc(x7, x7, vc);  // !V
 
+  Register old_fpcr = x15;
+  __ Mrs(old_fpcr, FPCR);
+
   // All core FPCR fields must be writable.
   __ Mov(x8, fpcr_core);
   __ Msr(FPCR, x8);
@@ -7164,6 +7167,8 @@ TEST(system_msr) {
   __ Msr(FPCR, x10);
   __ Mrs(x10, FPCR);
 #endif
+
+  __ Msr(FPCR, old_fpcr);
 
   END();
 


### PR DESCRIPTION
In particular, the test changed the rounding mode, which caused another test to fail when run on AArch64 hardware with --run-all.