### PR TITLE
Add convenient size-conversions for CPURegister.

### DIFF
--- a/src/aarch64/registers-aarch64.cc
+++ b/src/aarch64/registers-aarch64.cc
@@ -128,6 +128,18 @@ bool CPURegister::IsValid() const {
          IsValidPRegister() || IsValidCRegister();
 }
 
+CPURegister CPURegister::WithSizeInBits(int size_in_bits) const {
+  VIXL_ASSERT(IsScalar());
+  VIXL_ASSERT(IsUnqualified());
+  CPURegister result = *this;
+  result.size_ = EncodeSizeInBits(size_in_bits);
+  result.lane_size_ = result.size_;
+  VIXL_ASSERT(result.IsValid());
+  VIXL_ASSERT(Aliases(result));
+  VIXL_ASSERT(IsSameBank(result));
+  return result;
+}
+
 // Most coersions simply invoke the necessary constructor.
 #define VIXL_CPUREG_COERCION_LIST(U) \
   U(Register, W, R)                  \

--- a/src/aarch64/registers-aarch64.h
+++ b/src/aarch64/registers-aarch64.h
@@ -300,6 +300,23 @@ class CPURegister {
   ZRegister Z() const;
   PRegister P() const;
 
+  // Return a register with the specified size, aliasing this one.
+  // This is valid only for unqualified scalar formats.
+  //
+  // For example:
+  //   x0.WithSizeInBits(kCRegSize) returns c0.
+  CPURegister WithSizeInBits(int size_in_bits) const;
+  // For example:
+  //   x0.WithSizeInBytes(sizeof(void*)) returns c0 on a purecap host.
+  CPURegister WithSizeInBytes(int size_in_bytes) const {
+    return WithSizeInBits(size_in_bytes * kBitsPerByte);
+  }
+  // For example:
+  //   x0.WithSameSizeAs(c12) returns c0.
+  CPURegister WithSameSizeAs(CPURegister other) const {
+    return WithSizeInBits(other.GetSizeInBits());
+  }
+
   // Utilities for kRegister and kCRegister types.
 
   bool IsZero() const {

--- a/test/aarch64/test-api-morello-aarch64.cc
+++ b/test/aarch64/test-api-morello-aarch64.cc
@@ -55,6 +55,13 @@ TEST(morello_c_registers) {
   VIXL_CHECK(c0.Is(x0.C()));
   VIXL_CHECK(c0.Is(w0.C()));
 
+  VIXL_CHECK(x0.WithSizeInBits(kCRegSize).Is(c0));
+  VIXL_CHECK(x0.WithSizeInBytes(kCRegSizeInBytes).Is(c0));
+  VIXL_CHECK(x0.WithSameSizeAs(c12).Is(c0));
+  VIXL_CHECK(w0.WithSizeInBits(kCRegSize).Is(c0));
+  VIXL_CHECK(w0.WithSizeInBytes(kCRegSizeInBytes).Is(c0));
+  VIXL_CHECK(w0.WithSameSizeAs(c12).Is(c0));
+
   VIXL_CHECK(AreAliased(c5, c5));
   VIXL_CHECK(AreAliased(c5, w5));
   VIXL_CHECK(AreAliased(c5, x5));


### PR DESCRIPTION
Morello purecap porting will frequently need to derive an aliasing register with a given size, for example to match the host pointer size. This is quite a verbose operation in current VIXL, and is easy to get wrong. This patch adds a convenience helper.