### PR TITLE
Update to C++17

### DIFF
--- a/src/globals-vixl.h
+++ b/src/globals-vixl.h
@@ -27,8 +27,8 @@
 #ifndef VIXL_GLOBALS_H
 #define VIXL_GLOBALS_H
 
-#if __cplusplus < 201402L
-#error VIXL requires C++14
+#if __cplusplus < 201703L
+#error VIXL requires C++17
 #endif
 
 // Get standard C99 macros for integer types.

--- a/tools/code_coverage.sh
+++ b/tools/code_coverage.sh
@@ -38,7 +38,7 @@ fi
 export CXX=clang++
 export LLVM_PROFILE_FILE=$(mktemp)
 PROFDATA=$(mktemp)
-BUILDDIR="obj/target_a64/mode_debug/symbols_on/compiler_clang++/std_c++14/simulator_aarch64/negative_testing_off/code_buffer_allocator_mmap"
+BUILDDIR="obj/target_a64/mode_debug/symbols_on/compiler_clang++/std_c++17/simulator_aarch64/negative_testing_off/code_buffer_allocator_mmap"
 RUNNER="$BUILDDIR/test/test-runner"
 
 # Build with code coverage instrumentation enabled.

--- a/tools/config.py
+++ b/tools/config.py
@@ -44,7 +44,7 @@ dir_aarch32_traces     = os.path.join(dir_tests, 'aarch32', 'traces')
 # The full list of available build modes.
 build_options_modes = ['debug', 'release']
 # The list of C++ standard to test for. The first value is used as the default.
-tested_cpp_standards = ['c++14']
+tested_cpp_standards = ['c++17']
 # The list of compilers tested.
 tested_compilers = ['clang++', 'g++']
 # The list of target arch/isa options to test with. Do not list 'all' as an


### PR DESCRIPTION
Update the default build to use C++17 instead of C++14. This enables usage of C++17 features in VIXL.

Note: this removes C++14 as a testing target as use of C++17 features will break building with C++14.