### PR TITLE
Support PMULL for 1Q destination vectors

### DIFF
--- a/src/aarch64/assembler-aarch64.cc
+++ b/src/aarch64/assembler-aarch64.cc
@@ -2913,6 +2913,25 @@ void Assembler::st1(const VRegister& vt, int lane, const MemOperand& dst) {
   LoadStoreStructSingle(vt, lane, dst, NEONLoadStoreSingleStructStore1);
 }
 
+void Assembler::pmull(const VRegister& vd,
+                      const VRegister& vn,
+                      const VRegister& vm) {
+  VIXL_ASSERT(CPUHas(CPUFeatures::kNEON));
+  VIXL_ASSERT(AreSameFormat(vn, vm));
+  VIXL_ASSERT((vn.Is8B() && vd.Is8H()) || (vn.Is1D() && vd.Is1Q()));
+  VIXL_ASSERT(CPUHas(CPUFeatures::kPmull1Q) || vd.Is8H());
+  Emit(VFormat(vn) | NEON_PMULL | Rm(vm) | Rn(vn) | Rd(vd));
+}
+
+void Assembler::pmull2(const VRegister& vd,
+                       const VRegister& vn,
+                       const VRegister& vm) {
+  VIXL_ASSERT(CPUHas(CPUFeatures::kNEON));
+  VIXL_ASSERT(AreSameFormat(vn, vm));
+  VIXL_ASSERT((vn.Is16B() && vd.Is8H()) || (vn.Is2D() && vd.Is1Q()));
+  VIXL_ASSERT(CPUHas(CPUFeatures::kPmull1Q) || vd.Is8H());
+  Emit(VFormat(vn) | NEON_PMULL2 | Rm(vm) | Rn(vn) | Rd(vd));
+}
 
 void Assembler::NEON3DifferentL(const VRegister& vd,
                                 const VRegister& vn,
@@ -2960,8 +2979,6 @@ void Assembler::NEON3DifferentHN(const VRegister& vd,
 
 // clang-format off
 #define NEON_3DIFF_LONG_LIST(V) \
-  V(pmull,  NEON_PMULL,  vn.IsVector() && vn.Is8B())                           \
-  V(pmull2, NEON_PMULL2, vn.IsVector() && vn.Is16B())                          \
   V(saddl,  NEON_SADDL,  vn.IsVector() && vn.IsD())                            \
   V(saddl2, NEON_SADDL2, vn.IsVector() && vn.IsQ())                            \
   V(sabal,  NEON_SABAL,  vn.IsVector() && vn.IsD())                            \

--- a/src/aarch64/assembler-aarch64.h
+++ b/src/aarch64/assembler-aarch64.h
@@ -7540,6 +7540,8 @@ class Assembler : public vixl::internal::AssemblerBase {
   static Instr VFormat(VRegister vd) {
     if (vd.Is64Bits()) {
       switch (vd.GetLanes()) {
+        case 1:
+          return NEON_1D;
         case 2:
           return NEON_2S;
         case 4:

--- a/src/aarch64/cpu-features-auditor-aarch64.h
+++ b/src/aarch64/cpu-features-auditor-aarch64.h
@@ -127,6 +127,7 @@ class CPUFeaturesAuditor : public DecoderVisitor {
       uint32_t,
       std::function<void(CPUFeaturesAuditor*, const Instruction*)>>;
   static const FormToVisitorFnMap* GetFormToVisitorFnMap();
+  uint32_t form_hash_;
 };
 
 }  // namespace aarch64

--- a/src/aarch64/decoder-visitor-map-aarch64.h
+++ b/src/aarch64/decoder-visitor-map-aarch64.h
@@ -2074,7 +2074,6 @@
       {"scvtf_asimdmiscfp16_r"_h, &VISITORCLASS::VisitNEON2RegMiscFP16},       \
       {"ucvtf_asimdmiscfp16_r"_h, &VISITORCLASS::VisitNEON2RegMiscFP16},       \
       {"addhn_asimddiff_n"_h, &VISITORCLASS::VisitNEON3Different},             \
-      {"pmull_asimddiff_l"_h, &VISITORCLASS::VisitNEON3Different},             \
       {"raddhn_asimddiff_n"_h, &VISITORCLASS::VisitNEON3Different},            \
       {"rsubhn_asimddiff_n"_h, &VISITORCLASS::VisitNEON3Different},            \
       {"sabal_asimddiff_l"_h, &VISITORCLASS::VisitNEON3Different},             \
@@ -2827,6 +2826,7 @@
       {"fmlal_asimdsame_f"_h, &VISITORCLASS::VisitNEON3Same},                  \
       {"fmlsl2_asimdsame_f"_h, &VISITORCLASS::VisitNEON3Same},                 \
       {"fmlsl_asimdsame_f"_h, &VISITORCLASS::VisitNEON3Same},                  \
+      {"pmull_asimddiff_l"_h, &VISITORCLASS::VisitNEON3Different},             \
       {"ushll_asimdshf_l"_h, &VISITORCLASS::VisitNEONShiftImmediate},          \
       {"sshll_asimdshf_l"_h, &VISITORCLASS::VisitNEONShiftImmediate},          \
       {"shrn_asimdshf_n"_h, &VISITORCLASS::VisitNEONShiftImmediate},           \

--- a/src/aarch64/disasm-aarch64.h
+++ b/src/aarch64/disasm-aarch64.h
@@ -228,6 +228,7 @@ class Disassembler : public DecoderVisitor {
   void DisassembleNEONScalarShiftRightNarrowImm(const Instruction* instr);
   void DisassembleNEONScalar2RegMiscOnlyD(const Instruction* instr);
   void DisassembleNEONFPScalar2RegMisc(const Instruction* instr);
+  void DisassembleNEONPolynomialMul(const Instruction* instr);
 
   void DisassembleMTELoadTag(const Instruction* instr);
   void DisassembleMTEStoreTag(const Instruction* instr);

--- a/src/aarch64/instructions-aarch64.cc
+++ b/src/aarch64/instructions-aarch64.cc
@@ -1011,6 +1011,8 @@ VectorFormat VectorFormatHalfWidth(VectorFormat vform) {
       return kFormat4H;
     case kFormat2D:
       return kFormat2S;
+    case kFormat1Q:
+      return kFormat1D;
     case kFormatH:
       return kFormatB;
     case kFormatS:
@@ -1095,6 +1097,8 @@ VectorFormat VectorFormatHalfWidthDoubleLanes(VectorFormat vform) {
       return kFormat2S;
     case kFormat2D:
       return kFormat4S;
+    case kFormat1Q:
+      return kFormat2D;
     case kFormatVnH:
       return kFormatVnB;
     case kFormatVnS:
@@ -1246,6 +1250,7 @@ unsigned RegisterSizeInBitsFromFormat(VectorFormat vform) {
     case kFormat8H:
     case kFormat4S:
     case kFormat2D:
+    case kFormat1Q:
       return kQRegSize;
     default:
       VIXL_UNREACHABLE();
@@ -1283,6 +1288,7 @@ unsigned LaneSizeInBitsFromFormat(VectorFormat vform) {
     case kFormat2D:
     case kFormatVnD:
       return 64;
+    case kFormat1Q:
     case kFormatVnQ:
       return 128;
     case kFormatVnO:
@@ -1348,6 +1354,7 @@ int LaneCountFromFormat(VectorFormat vform) {
     case kFormat2D:
       return 2;
     case kFormat1D:
+    case kFormat1Q:
     case kFormatB:
     case kFormatH:
     case kFormatS:

--- a/src/aarch64/instructions-aarch64.h
+++ b/src/aarch64/instructions-aarch64.h
@@ -217,9 +217,10 @@ enum VectorFormat {
   kFormatVnQ = kFormatSVEQ | kFormatSVE,
   kFormatVnO = kFormatSVEO | kFormatSVE,
 
-  // An artificial value, used by simulator trace tests and a few oddball
+  // Artificial values, used by simulator trace tests and a few oddball
   // instructions (such as FMLAL).
-  kFormat2H = 0xfffffffe
+  kFormat2H = 0xfffffffe,
+  kFormat1Q = 0xfffffffd
 };
 
 // Instructions. ---------------------------------------------------------------

--- a/src/aarch64/registers-aarch64.cc
+++ b/src/aarch64/registers-aarch64.cc
@@ -153,7 +153,8 @@ VIXL_CPUREG_COERCION_LIST(VIXL_DEFINE_CPUREG_COERCION)
   V(2, S)                                 \
   V(4, S)                                 \
   V(1, D)                                 \
-  V(2, D)
+  V(2, D)                                 \
+  V(1, Q)
 #define VIXL_DEFINE_CPUREG_NEON_COERCION(LANES, LANE_TYPE)             \
   VRegister VRegister::V##LANES##LANE_TYPE() const {                   \
     VIXL_ASSERT(IsVRegister());                                        \

--- a/src/aarch64/registers-aarch64.h
+++ b/src/aarch64/registers-aarch64.h
@@ -575,6 +575,7 @@ class VRegister : public CPURegister {
   VRegister V4S() const;
   VRegister V1D() const;
   VRegister V2D() const;
+  VRegister V1Q() const;
   VRegister S4B() const;
 
   bool IsValid() const { return IsValidVRegister(); }

--- a/test/aarch64/test-assembler-neon-aarch64.cc
+++ b/test/aarch64/test-assembler-neon-aarch64.cc
@@ -10975,6 +10975,24 @@ TEST(neon_usdot_element) {
   }
 }
 
+TEST(neon_pmull_regression_test) {
+  SETUP_WITH_FEATURES(CPUFeatures::kNEON);
+
+  START();
+  __ Movi(v0.V2D(), 0xdecafc0ffee);
+  __ Pmull(v0.V8H(), v0.V8B(), v0.V8B());
+
+  __ Movi(v1.V2D(), 0xaaaaaaaa55555555);
+  __ Pmull2(v1.V8H(), v1.V16B(), v1.V16B());
+  END();
+
+  if (CAN_RUN()) {
+    RUN();
+    ASSERT_EQUAL_128(0x0000000000515450, 0x4455500055555454, q0);
+    ASSERT_EQUAL_128(0x4444444444444444, 0x1111111111111111, q1);
+  }
+}
+
 TEST(zero_high_b) {
   SETUP_WITH_FEATURES(CPUFeatures::kSVE, CPUFeatures::kNEON, CPUFeatures::kRDM);
   START();

--- a/test/aarch64/test-cpu-features-aarch64.cc
+++ b/test/aarch64/test-cpu-features-aarch64.cc
@@ -3778,5 +3778,12 @@ TEST_FP_FCMA_NEON_NEONHALF(fcmla_1, fcmla(v0.V8H(), v1.V8H(), v2.H(), 2, 180))
 TEST_FP_FCMA_NEON_NEONHALF(fcmla_2, fcmla(v0.V4H(), v1.V4H(), v2.V4H(), 180))
 TEST_FP_FCMA_NEON_NEONHALF(fcmla_3, fcmla(v0.V8H(), v1.V8H(), v2.V8H(), 0))
 
+#define TEST_FEAT(NAME, ASM)                                            \
+  TEST_TEMPLATE(CPUFeatures(CPUFeatures::kNEON, CPUFeatures::kPmull1Q), \
+                NEON_Pmull1Q_##NAME,                                    \
+                ASM)
+TEST_FEAT(pmull1q_0, pmull(v5.V1Q(), v6.V1D(), v7.V1D()))
+#undef TEST_FEAT
+
 }  // namespace aarch64
 }  // namespace vixl

--- a/test/aarch64/test-disasm-neon-aarch64.cc
+++ b/test/aarch64/test-disasm-neon-aarch64.cc
@@ -2904,6 +2904,10 @@ TEST(neon_3different) {
                 "pmull v0.8h, v1.8b, v2.8b");
   COMPARE_MACRO(Pmull2(v2.V8H(), v3.V16B(), v4.V16B()),
                 "pmull2 v2.8h, v3.16b, v4.16b");
+  COMPARE_MACRO(Pmull(v5.V1Q(), v6.V1D(), v7.V1D()),
+                "pmull v5.1q, v6.1d, v7.1d");
+  COMPARE_MACRO(Pmull2(v8.V1Q(), v9.V2D(), v10.V2D()),
+                "pmull2 v8.1q, v9.2d, v10.2d");
 
   CLEANUP();
 }
@@ -4562,8 +4566,6 @@ TEST(neon_unallocated_regression_test) {
   COMPARE_PREFIX(dci(0x2efb9dbd), "unallocated");  // pmul v.und, v.und, v.und
   COMPARE_PREFIX(dci(0x4eace101), "unallocated");  // pmull v.d, v.s, v.s
   COMPARE_PREFIX(dci(0x0e6de3ad), "unallocated");  // pmull v.s, v.h, v.h
-  COMPARE_PREFIX(dci(0x4ee3e2c0), "unallocated");  // pmull v.und, v.d, v.d
-  COMPARE_PREFIX(dci(0x0eede060), "unallocated");  // pmull v.und, v.und, v.und
   COMPARE_PREFIX(dci(0x6ee00afd), "unallocated");  // rev v.d, v.d
   COMPARE_PREFIX(dci(0x4e601975), "unallocated");  // rev v.h, v.h
   COMPARE_PREFIX(dci(0x4ea019f3), "unallocated");  // rev v.s, v.s

--- a/test/aarch64/test-simulator-aarch64.cc
+++ b/test/aarch64/test-simulator-aarch64.cc
@@ -5188,7 +5188,8 @@ void HandleSegFault(int sig, siginfo_t* info, void* context) {
   // next instruction, after this handler.
   uc->uc_mcontext.gregs[REG_RIP] = sim->GetSignalReturnAddress();
   // Return that the memory read failed.
-  uc->uc_mcontext.gregs[REG_RAX] = static_cast<greg_t>(MemoryReadResult::Failure);
+  uc->uc_mcontext.gregs[REG_RAX] =
+      static_cast<greg_t>(MemoryReadResult::Failure);
 }
 
 TEST(ImplicitCheck) {

--- a/test/aarch64/test-simulator-sve-aarch64.cc
+++ b/test/aarch64/test-simulator-sve-aarch64.cc
@@ -267,5 +267,132 @@ TEST_SVE(sve_fmatmul_s) {
   }
 }
 
+// Below here, there are tests for Neon instructions. As these forms of test
+// check the entire register state, they also need SVE features.
+
+TEST_SVE(neon_pmull) {
+  SVE_SETUP_WITH_FEATURES(CPUFeatures::kSVE,
+                          CPUFeatures::kNEON,
+                          CPUFeatures::kCRC32,
+                          CPUFeatures::kPmull1Q);
+  START();
+
+  SetInitialMachineState(&masm);
+  // state = 0xe2bd2480
+
+  {
+    ExactAssemblyScope scope(&masm, 40 * kInstructionSize);
+    __ dci(0x4e20e000);  // pmull2 v0.8h, v0.16b, v0.16b
+    // vl128 state = 0x5eba4d4f
+    __ dci(0x4e20e228);  // pmull2 v8.8h, v17.16b, v0.16b
+    // vl128 state = 0x86bceb87
+    __ dci(0x4ee0e22a);  // pmull2 v10.1q, v17.2d, v0.2d
+    // vl128 state = 0x1332fe02
+    __ dci(0x0ee8e222);  // pmull v2.1q, v17.1d, v8.1d
+    // vl128 state = 0xd357dc7b
+    __ dci(0x4eece226);  // pmull2 v6.1q, v17.2d, v12.2d
+    // vl128 state = 0xdff409ad
+    __ dci(0x0eece276);  // pmull v22.1q, v19.1d, v12.1d
+    // vl128 state = 0xd8af1dc6
+    __ dci(0x0eede232);  // pmull v18.1q, v17.1d, v13.1d
+    // vl128 state = 0x41e6ed0e
+    __ dci(0x0efde216);  // pmull v22.1q, v16.1d, v29.1d
+    // vl128 state = 0x1f10365f
+    __ dci(0x0effe23e);  // pmull v30.1q, v17.1d, v31.1d
+    // vl128 state = 0x9779ece5
+    __ dci(0x0ee7e23f);  // pmull v31.1q, v17.1d, v7.1d
+    // vl128 state = 0x11fc8ce9
+    __ dci(0x0ee2e23e);  // pmull v30.1q, v17.1d, v2.1d
+    // vl128 state = 0x101d5a6f
+    __ dci(0x0ee2e23c);  // pmull v28.1q, v17.1d, v2.1d
+    // vl128 state = 0xcc4fe26e
+    __ dci(0x0eeae27d);  // pmull v29.1q, v19.1d, v10.1d
+    // vl128 state = 0xc84be9f4
+    __ dci(0x4eeae24d);  // pmull2 v13.1q, v18.2d, v10.2d
+    // vl128 state = 0x2fc540b4
+    __ dci(0x4eeae25d);  // pmull2 v29.1q, v18.2d, v10.2d
+    // vl128 state = 0x1b2d99cd
+    __ dci(0x4eeae2ed);  // pmull2 v13.1q, v23.2d, v10.2d
+    // vl128 state = 0x8a278b95
+    __ dci(0x4eeae2e9);  // pmull2 v9.1q, v23.2d, v10.2d
+    // vl128 state = 0x3359b4c8
+    __ dci(0x4efee2e8);  // pmull2 v8.1q, v23.2d, v30.2d
+    // vl128 state = 0x5c25ed31
+    __ dci(0x4effe3e0);  // pmull2 v0.1q, v31.2d, v31.2d
+    // vl128 state = 0x28ff67d1
+    __ dci(0x4eefe3d0);  // pmull2 v16.1q, v30.2d, v15.2d
+    // vl128 state = 0x1543436d
+    __ dci(0x4ee7e2d1);  // pmull2 v17.1q, v22.2d, v7.2d
+    // vl128 state = 0x71b8bc90
+    __ dci(0x4eefe3d5);  // pmull2 v21.1q, v30.2d, v15.2d
+    // vl128 state = 0x3d35ca02
+    __ dci(0x4eefe314);  // pmull2 v20.1q, v24.2d, v15.2d
+    // vl128 state = 0x40e8fade
+    __ dci(0x4eefe310);  // pmull2 v16.1q, v24.2d, v15.2d
+    // vl128 state = 0xb8affb87
+    __ dci(0x4eefe300);  // pmull2 v0.1q, v24.2d, v15.2d
+    // vl128 state = 0x4824ee5c
+    __ dci(0x4eede350);  // pmull2 v16.1q, v26.2d, v13.2d
+    // vl128 state = 0x39202868
+    __ dci(0x4ee7e354);  // pmull2 v20.1q, v26.2d, v7.2d
+    // vl128 state = 0xc8fde340
+    __ dci(0x4e27e356);  // pmull2 v22.8h, v26.16b, v7.16b
+    // vl128 state = 0x0f02316b
+    __ dci(0x4e37e15e);  // pmull2 v30.8h, v10.16b, v23.16b
+    // vl128 state = 0xced4f8bd
+    __ dci(0x4e33e05f);  // pmull2 v31.8h, v2.16b, v19.16b
+    // vl128 state = 0x0c76bdb3
+    __ dci(0x0e23e05e);  // pmull v30.8h, v2.8b, v3.8b
+    // vl128 state = 0x0e36962b
+    __ dci(0x4e23e25f);  // pmull2 v31.8h, v18.16b, v3.16b
+    // vl128 state = 0x11a8dcc3
+    __ dci(0x4e23e25b);  // pmull2 v27.8h, v18.16b, v3.16b
+    // vl128 state = 0xf01bfe16
+    __ dci(0x4e23e259);  // pmull2 v25.8h, v18.16b, v3.16b
+    // vl128 state = 0xea351afe
+    __ dci(0x4e22e2c9);  // pmull2 v9.8h, v22.16b, v2.16b
+    // vl128 state = 0x16e933ef
+    __ dci(0x4e3ae2c8);  // pmull2 v8.8h, v22.16b, v26.16b
+    // vl128 state = 0x02528a2a
+    __ dci(0x4e32e249);  // pmull2 v9.8h, v18.16b, v18.16b
+    // vl128 state = 0xe7e20633
+    __ dci(0x4e36e20d);  // pmull2 v13.8h, v16.16b, v22.16b
+    // vl128 state = 0x6f231732
+    __ dci(0x4e36e205);  // pmull2 v5.8h, v16.16b, v22.16b
+    // vl128 state = 0x423eb7ea
+    __ dci(0x4e22e20d);  // pmull2 v13.8h, v16.16b, v2.16b
+    // vl128 state = 0xfc0d1c14
+  }
+
+  uint32_t state;
+  ComputeMachineStateHash(&masm, &state);
+  __ Mov(x0, reinterpret_cast<uint64_t>(&state));
+  __ Ldr(w0, MemOperand(x0));
+
+  END();
+  if (CAN_RUN()) {
+    RUN();
+    uint32_t expected_hashes[] = {
+        0xfc0d1c14,
+        0x4cb040a3,
+        0x4b913ebe,
+        0xfa35b836,
+        0x78745d20,
+        0x6666b09a,
+        0xee2868f4,
+        0x1936a795,
+        0x1025244a,
+        0xe8551950,
+        0xae73af02,
+        0x0fdd5fc7,
+        0x22e9827b,
+        0x384ce1ac,
+        0xc833cbeb,
+        0x255baab5,
+    };
+    ASSERT_EQUAL_64(expected_hashes[core.GetSVELaneCount(kQRegSize) - 1], x0);
+  }
+}
+
 }  // namespace aarch64
 }  // namespace vixl


### PR DESCRIPTION
Extend the Neon PMULL instruction to support 1Q destination registers when the CPU feature is supported.

Co-authored-by: Anton Kirilov <anton.kirilov@arm.com>