### PR TITLE
Fix zeroing part of SVE register for Neon instructions

### DIFF
--- a/src/aarch64/logic-aarch64.cc
+++ b/src/aarch64/logic-aarch64.cc
@@ -198,6 +198,7 @@ bool Simulator::ld1(VectorFormat vform,
                     LogicVRegister dst,
                     int index,
                     uint64_t addr) {
+  dst.ClearForWrite(vform);
   return LoadLane(dst, vform, index, addr);
 }
 
@@ -2275,7 +2276,10 @@ LogicVRegister Simulator::extractnarrow(VectorFormat dstform,
     }
   }
 
-  if (!upperhalf) {
+  if (upperhalf) {
+    // Clear any bits beyond a Q register.
+    dst.ClearForWrite(kFormat16B);
+  } else {
     dst.ClearForWrite(dstform);
   }
   return dst;
@@ -2725,7 +2729,7 @@ LogicVRegister Simulator::fcmla(VectorFormat vform,
                                 int index,
                                 int rot) {
   if (LaneSizeInBitsFromFormat(vform) == kHRegSize) {
-    VIXL_UNIMPLEMENTED();
+    fcmla<SimFloat16>(vform, dst, src1, src2, dst, index, rot);
   } else if (LaneSizeInBitsFromFormat(vform) == kSRegSize) {
     fcmla<float>(vform, dst, src1, src2, dst, index, rot);
   } else {
@@ -5981,6 +5985,7 @@ LogicVRegister Simulator::fcvtu(VectorFormat vform,
 LogicVRegister Simulator::fcvtl(VectorFormat vform,
                                 LogicVRegister dst,
                                 const LogicVRegister& src) {
+  dst.ClearForWrite(vform);
   if (LaneSizeInBitsFromFormat(vform) == kSRegSize) {
     for (int i = LaneCountFromFormat(vform) - 1; i >= 0; i--) {
       // TODO: Full support for SimFloat16 in SimRegister(s).
@@ -6001,6 +6006,7 @@ LogicVRegister Simulator::fcvtl(VectorFormat vform,
 LogicVRegister Simulator::fcvtl2(VectorFormat vform,
                                  LogicVRegister dst,
                                  const LogicVRegister& src) {
+  dst.ClearForWrite(vform);
   int lane_count = LaneCountFromFormat(vform);
   if (LaneSizeInBitsFromFormat(vform) == kSRegSize) {
     for (int i = 0; i < lane_count; i++) {
@@ -6046,6 +6052,7 @@ LogicVRegister Simulator::fcvtn(VectorFormat vform,
 LogicVRegister Simulator::fcvtn2(VectorFormat vform,
                                  LogicVRegister dst,
                                  const LogicVRegister& src) {
+  dst.ClearForWrite(vform);
   int lane_count = LaneCountFromFormat(vform) / 2;
   if (LaneSizeInBitsFromFormat(vform) == kHRegSize) {
     for (int i = lane_count - 1; i >= 0; i--) {
@@ -6089,6 +6096,7 @@ LogicVRegister Simulator::fcvtxn2(VectorFormat vform,
                                   LogicVRegister dst,
                                   const LogicVRegister& src) {
   VIXL_ASSERT(LaneSizeInBitsFromFormat(vform) == kSRegSize);
+  dst.ClearForWrite(vform);
   int lane_count = LaneCountFromFormat(vform) / 2;
   for (int i = lane_count - 1; i >= 0; i--) {
     dst.SetFloat(i + lane_count,

--- a/src/aarch64/simulator-aarch64.cc
+++ b/src/aarch64/simulator-aarch64.cc
@@ -6143,6 +6143,8 @@ void Simulator::VisitFPIntegerConvert(const Instruction* instr) {
       WriteDRegisterBits(dst, ReadXRegister(src));
       break;
     case FMOV_d1_x:
+      // Zero bits beyond the MSB of a Q register.
+      mov(kFormat16B, ReadVRegister(dst), ReadVRegister(dst));
       LogicVRegister(ReadVRegister(dst))
           .SetUint(kFormatD, 1, ReadXRegister(src));
       break;


### PR DESCRIPTION
Fix some Neon lengthening, narrowing and insertion instructions that should zero the upper bits of SVE registers, and add regression tests.

In particular, this fixes ADDHN2, FCVTL, FCVTL2, FCVTN2, FCVTXN2, FMOV (to d[1]), LD1 (single element), RADDHN2, RSUBHN2, SQXTN2, SQXTUN2, SUBHN2, UQXTN2 and XTN2 for simulated systems with VL > 128 bits.

Also, enable FCMLA by-element instructions, for which code already exists but wasn't being called in simulation.