### PR TITLE
fix: avoid template-id-cdtor warning with GCC 14

### DIFF
--- a/src/pool-manager-impl.h
+++ b/src/pool-manager-impl.h
@@ -487,7 +487,7 @@ void PoolManager<T>::Release(T pc) {
 }
 
 template <typename T>
-PoolManager<T>::~PoolManager<T>() VIXL_NEGATIVE_TESTING_ALLOW_EXCEPTION {
+PoolManager<T>::~PoolManager() VIXL_NEGATIVE_TESTING_ALLOW_EXCEPTION {
 #ifdef VIXL_DEBUG
   // Check for unbound objects.
   for (objects_iter iter = objects_.begin(); iter != objects_.end(); ++iter) {


### PR DESCRIPTION
C++20's DR 2237 forbids using template-ids in constructors and destructors, and GCC 14 started warning about this.