### PR TITLE
Replace rand48 with std::linear_congruential_engine in simulator

### DIFF
--- a/src/aarch64/logic-aarch64.cc
+++ b/src/aarch64/logic-aarch64.cc
@@ -168,11 +168,12 @@ SimFloat16 Simulator::UFixedToFloat16(uint64_t src,
 
 
 uint64_t Simulator::GenerateRandomTag(uint16_t exclude) {
-  uint64_t rtag = nrand48(rand_state_) >> 28;
+  // Generate a 4 bit integer from a 48bit random number
+  uint64_t rtag = rand_gen_() >> 44;
   VIXL_ASSERT(IsUint4(rtag));
 
   if (exclude == 0) {
-    exclude = nrand48(rand_state_) >> 27;
+    exclude = rand_gen_() >> 44;
   }
 
   // TODO: implement this to better match the specification, which calls for a
@@ -7487,7 +7488,7 @@ void Simulator::SVEFaultTolerantLoadHelper(VectorFormat vform,
 
   // Non-faulting loads are allowed to fail arbitrarily. To stress user
   // code, fail a random element in roughly one in eight full-vector loads.
-  uint32_t rnd = static_cast<uint32_t>(jrand48(rand_state_));
+  uint32_t rnd = static_cast<uint32_t>(rand_gen_());
   int fake_fault_at_lane = rnd % (LaneCountFromFormat(vform) * 8);
 
   for (int i = 0; i < LaneCountFromFormat(vform); i++) {

--- a/src/aarch64/simulator-aarch64.cc
+++ b/src/aarch64/simulator-aarch64.cc
@@ -594,9 +594,8 @@ Simulator::Simulator(Decoder* decoder, FILE* stream, SimStack::Allocated stack)
   guard_pages_ = false;
 
   // Initialize the common state of RNDR and RNDRRS.
-  uint16_t seed[3] = {11, 22, 33};
-  VIXL_STATIC_ASSERT(sizeof(seed) == sizeof(rand_state_));
-  memcpy(rand_state_, seed, sizeof(rand_state_));
+  uint64_t seed = (11 + (22 << 16) + (static_cast<uint64_t>(33) << 32));
+  rand_gen_.seed(seed);
 
   // Initialize all bits of pseudo predicate register to true.
   LogicPRegister ones(pregister_all_true_);
@@ -6947,8 +6946,8 @@ void Simulator::VisitSystem(const Instruction* instr) {
           break;
         case RNDR:
         case RNDRRS: {
-          uint64_t high = jrand48(rand_state_);
-          uint64_t low = jrand48(rand_state_);
+          uint64_t high = rand_gen_();
+          uint64_t low = rand_gen_();
           uint64_t rand_num = (high << 32) | (low & 0xffffffff);
           WriteXRegister(instr->GetRt(), rand_num);
           // Simulate successful random number generation.

--- a/src/aarch64/simulator-aarch64.h
+++ b/src/aarch64/simulator-aarch64.h
@@ -29,6 +29,7 @@
 
 #include <memory>
 #include <mutex>
+#include <random>
 #include <unordered_map>
 #include <vector>
 
@@ -5431,11 +5432,15 @@ class Simulator : public DecoderVisitor {
   CPUFeaturesAuditor cpu_features_auditor_;
   std::vector<CPUFeatures> saved_cpu_features_;
 
-  // State for *rand48 functions, used to simulate randomness with repeatable
+  // linear_congruential_engine, used to simulate randomness with repeatable
   // behaviour (so that tests are deterministic). This is used to simulate RNDR
   // and RNDRRS, as well as to simulate a source of entropy for architecturally
   // undefined behaviour.
-  uint16_t rand_state_[3];
+  std::linear_congruential_engine<uint64_t,
+                                  0x5DEECE66D,
+                                  0xB,
+                                  static_cast<uint64_t>(1) << 48>
+      rand_gen_;
 
   // A configurable size of SVE vector registers.
   unsigned vector_length_;


### PR DESCRIPTION
I'm somewhat hoping to get the simulator building on Windows, this requires some POSIX interfaces to be replaced/removed.
I opted to work on replacing the various `*rand48()` functions.

As per https://linux.die.net/man/3/jrand48, these functions implement the linear congruential formula and provide the values I've used for the `std::linear_congruential_engine` template args.

It's not an exact replacement, as `*rand48` returns the upper 32-bits, while the std implementation returns the full 48bit number.
This has been accounted for in `GenerateRandomTag()`, but other locations have been left unadjusted.


