### PR TITLE
Fix compilation of Simulator/Debugger with MSVC

### DIFF
--- a/src/aarch64/cpu-features-auditor-aarch64.h
+++ b/src/aarch64/cpu-features-auditor-aarch64.h
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <unordered_map>
 
-#include "cpu-features.h"
+#include "../cpu-features.h"
 
 #include "decoder-aarch64.h"
 #include "decoder-visitor-map-aarch64.h"

--- a/src/aarch64/debugger-aarch64.cc
+++ b/src/aarch64/debugger-aarch64.cc
@@ -33,7 +33,6 @@
 #include <cstring>
 #include <errno.h>
 #include <limits>
-#include <unistd.h>
 
 namespace vixl {
 namespace aarch64 {
@@ -187,7 +186,7 @@ std::optional<Debugger::RegisterParsedFormat> Debugger::ParseRegString(
     return std::nullopt;
   }
 
-  return {{reg_prefix, *reg_code}};
+  return {{reg_prefix, static_cast<unsigned int>(*reg_code)}};
 }
 
 

--- a/src/aarch64/debugger-aarch64.h
+++ b/src/aarch64/debugger-aarch64.h
@@ -31,9 +31,9 @@
 #include <unordered_set>
 #include <vector>
 
+#include "../cpu-features.h"
 #include "../globals-vixl.h"
 #include "../utils-vixl.h"
-#include "cpu-features.h"
 
 #include "abi-aarch64.h"
 #include "cpu-features-auditor-aarch64.h"

--- a/src/aarch64/logic-aarch64.cc
+++ b/src/aarch64/logic-aarch64.cc
@@ -36,33 +36,33 @@ namespace aarch64 {
 using vixl::internal::SimFloat16;
 
 template <typename T>
-bool IsFloat64() {
+constexpr bool IsFloat64() {
   return false;
 }
 template <>
-bool IsFloat64<double>() {
+constexpr bool IsFloat64<double>() {
   return true;
 }
 
 template <typename T>
-bool IsFloat32() {
+constexpr bool IsFloat32() {
   return false;
 }
 template <>
-bool IsFloat32<float>() {
+constexpr bool IsFloat32<float>() {
   return true;
 }
 
 template <typename T>
-bool IsFloat16() {
+constexpr bool IsFloat16() {
   return false;
 }
 template <>
-bool IsFloat16<Float16>() {
+constexpr bool IsFloat16<Float16>() {
   return true;
 }
 template <>
-bool IsFloat16<SimFloat16>() {
+constexpr bool IsFloat16<SimFloat16>() {
   return true;
 }
 
@@ -173,7 +173,7 @@ uint64_t Simulator::GenerateRandomTag(uint16_t exclude) {
   VIXL_ASSERT(IsUint4(rtag));
 
   if (exclude == 0) {
-    exclude = rand_gen_() >> 44;
+    exclude = static_cast<uint16_t>(rand_gen_() >> 44);
   }
 
   // TODO: implement this to better match the specification, which calls for a
@@ -2539,10 +2539,10 @@ LogicVRegister Simulator::ext(VectorFormat vform,
   uint8_t result[kZRegMaxSizeInBytes] = {};
   int lane_count = LaneCountFromFormat(vform);
   for (int i = 0; i < lane_count - index; ++i) {
-    result[i] = src1.Uint(vform, i + index);
+    result[i] = static_cast<uint8_t>(src1.Uint(vform, i + index));
   }
   for (int i = 0; i < index; ++i) {
-    result[lane_count - index + i] = src2.Uint(vform, i);
+    result[lane_count - index + i] = static_cast<uint8_t>(src2.Uint(vform, i));
   }
   dst.ClearForWrite(vform);
   for (int i = 0; i < lane_count; ++i) {
@@ -4185,7 +4185,7 @@ LogicVRegister Simulator::sqrdmlash_d(VectorFormat vform,
 
     // Arithmetic shift the whole value right by `esize - 1` bits.
     accum.second = (accum.first << 1) | (accum.second >> (esize - 1));
-    accum.first = -(accum.first >> (esize - 1));
+    accum.first = UnsignedNegate(accum.first >> (esize - 1));
 
     // Perform saturation.
     bool is_pos = (accum.first == 0) ? true : false;
@@ -4563,7 +4563,7 @@ T Simulator::FPMulx(T op1, T op2) {
   if ((IsInf(op1) && (op2 == 0.0)) || (IsInf(op2) && (op1 == 0.0))) {
     // inf * 0.0 returns +/-2.0.
     T two = 2.0;
-    return copysign(1.0, op1) * copysign(1.0, op2) * two;
+    return copysign(T(1.0), op1) * copysign(T(1.0), op2) * two;
   }
   return FPMul(op1, op2);
 }
@@ -4573,8 +4573,8 @@ template <typename T>
 T Simulator::FPMulAdd(T a, T op1, T op2) {
   T result = FPProcessNaNs3(a, op1, op2);
 
-  T sign_a = copysign(1.0, a);
-  T sign_prod = copysign(1.0, op1) * copysign(1.0, op2);
+  T sign_a = copysign(T(1.0), a);
+  T sign_prod = copysign(T(1.0), op1) * copysign(T(1.0), op2);
   bool isinf_prod = IsInf(op1) || IsInf(op2);
   bool operation_generates_nan =
       (IsInf(op1) && (op2 == 0.0)) ||                     // inf * 0.0
@@ -4600,7 +4600,7 @@ T Simulator::FPMulAdd(T a, T op1, T op2) {
   // Work around broken fma implementations for exact zero results: The sign of
   // exact 0.0 results is positive unless both a and op1 * op2 are negative.
   if (((op1 == 0.0) || (op2 == 0.0)) && (a == 0.0)) {
-    return ((sign_a < T(0.0)) && (sign_prod < T(0.0))) ? -0.0 : 0.0;
+    return ((sign_a < T(0.0)) && (sign_prod < T(0.0))) ? T(-0.0) : T(0.0);
   }
 
   result = FusedMultiplyAdd(op1, op2, a);
@@ -4609,7 +4609,7 @@ T Simulator::FPMulAdd(T a, T op1, T op2) {
   // Work around broken fma implementations for rounded zero results: If a is
   // 0.0, the sign of the result is the sign of op1 * op2 before rounding.
   if ((a == 0.0) && (result == 0.0)) {
-    return copysign(0.0, sign_prod);
+    return copysign(T(0.0), sign_prod);
   }
 
   return result;
@@ -4671,9 +4671,9 @@ T Simulator::FPMax(T a, T b) {
 template <typename T>
 T Simulator::FPMaxNM(T a, T b) {
   if (IsQuietNaN(a) && !IsQuietNaN(b)) {
-    a = kFP64NegativeInfinity;
+    a = T(kFP64NegativeInfinity);
   } else if (!IsQuietNaN(a) && IsQuietNaN(b)) {
-    b = kFP64NegativeInfinity;
+    b = T(kFP64NegativeInfinity);
   }
 
   T result = FPProcessNaNs(a, b);
@@ -4698,9 +4698,9 @@ T Simulator::FPMin(T a, T b) {
 template <typename T>
 T Simulator::FPMinNM(T a, T b) {
   if (IsQuietNaN(a) && !IsQuietNaN(b)) {
-    a = kFP64PositiveInfinity;
+    a = T(kFP64PositiveInfinity);
   } else if (!IsQuietNaN(a) && IsQuietNaN(b)) {
-    b = kFP64PositiveInfinity;
+    b = T(kFP64PositiveInfinity);
   }
 
   T result = FPProcessNaNs(a, b);
@@ -4715,8 +4715,8 @@ T Simulator::FPRecipStepFused(T op1, T op2) {
     return two;
   } else if (IsInf(op1) || IsInf(op2)) {
     // Return +inf if signs match, otherwise -inf.
-    return ((op1 >= 0.0) == (op2 >= 0.0)) ? kFP64PositiveInfinity
-                                          : kFP64NegativeInfinity;
+    return ((op1 >= 0.0) == (op2 >= 0.0)) ? T(kFP64PositiveInfinity)
+                                          : T(kFP64NegativeInfinity);
   } else {
     return FusedMultiplyAdd(op1, op2, two);
   }
@@ -4745,8 +4745,8 @@ T Simulator::FPRSqrtStepFused(T op1, T op2) {
     return one_point_five;
   } else if (IsInf(op1) || IsInf(op2)) {
     // Return +inf if signs match, otherwise -inf.
-    return ((op1 >= 0.0) == (op2 >= 0.0)) ? kFP64PositiveInfinity
-                                          : kFP64NegativeInfinity;
+    return ((op1 >= 0.0) == (op2 >= 0.0)) ? T(kFP64PositiveInfinity)
+                                          : T(kFP64NegativeInfinity);
   } else {
     // The multiply-add-halve operation must be fully fused, so avoid interim
     // rounding by checking which operand can be losslessly divided by two
@@ -4775,7 +4775,7 @@ int32_t Simulator::FPToFixedJS(double value) {
       (value == kFP64NegativeInfinity)) {
     // +/- zero and infinity all return zero, however -0 and +/- Infinity also
     // unset the Z-flag.
-    result = 0.0;
+    result = 0;
     if ((value != 0.0) || std::signbit(value)) {
       Z = 0;
     }
@@ -5560,38 +5560,40 @@ LogicVRegister Simulator::fsqrt(VectorFormat vform,
 }
 
 
-#define DEFINE_NEON_FP_PAIR_OP(FNP, FN, OP)                                    \
-  LogicVRegister Simulator::FNP(VectorFormat vform,                            \
-                                LogicVRegister dst,                            \
-                                const LogicVRegister& src1,                    \
-                                const LogicVRegister& src2) {                  \
-    SimVRegister temp1, temp2;                                                 \
-    uzp1(vform, temp1, src1, src2);                                            \
-    uzp2(vform, temp2, src1, src2);                                            \
-    FN(vform, dst, temp1, temp2);                                              \
-    if (IsSVEFormat(vform)) {                                                  \
-      interleave_top_bottom(vform, dst, dst);                                  \
-    }                                                                          \
-    return dst;                                                                \
-  }                                                                            \
-                                                                               \
-  LogicVRegister Simulator::FNP(VectorFormat vform,                            \
-                                LogicVRegister dst,                            \
-                                const LogicVRegister& src) {                   \
-    if (vform == kFormatH) {                                                   \
-      SimFloat16 result(OP(SimFloat16(RawbitsToFloat16(src.Uint(vform, 0))),   \
-                           SimFloat16(RawbitsToFloat16(src.Uint(vform, 1))))); \
-      dst.SetUint(vform, 0, Float16ToRawbits(result));                         \
-    } else if (vform == kFormatS) {                                            \
-      float result = OP(src.Float<float>(0), src.Float<float>(1));             \
-      dst.SetFloat(0, result);                                                 \
-    } else {                                                                   \
-      VIXL_ASSERT(vform == kFormatD);                                          \
-      double result = OP(src.Float<double>(0), src.Float<double>(1));          \
-      dst.SetFloat(0, result);                                                 \
-    }                                                                          \
-    dst.ClearForWrite(vform);                                                  \
-    return dst;                                                                \
+#define DEFINE_NEON_FP_PAIR_OP(FNP, FN, OP)                                   \
+  LogicVRegister Simulator::FNP(VectorFormat vform,                           \
+                                LogicVRegister dst,                           \
+                                const LogicVRegister& src1,                   \
+                                const LogicVRegister& src2) {                 \
+    SimVRegister temp1, temp2;                                                \
+    uzp1(vform, temp1, src1, src2);                                           \
+    uzp2(vform, temp2, src1, src2);                                           \
+    FN(vform, dst, temp1, temp2);                                             \
+    if (IsSVEFormat(vform)) {                                                 \
+      interleave_top_bottom(vform, dst, dst);                                 \
+    }                                                                         \
+    return dst;                                                               \
+  }                                                                           \
+                                                                              \
+  LogicVRegister Simulator::FNP(VectorFormat vform,                           \
+                                LogicVRegister dst,                           \
+                                const LogicVRegister& src) {                  \
+    if (vform == kFormatH) {                                                  \
+      SimFloat16 result(OP(SimFloat16(RawbitsToFloat16(                       \
+                               static_cast<uint16_t>(src.Uint(vform, 0)))),   \
+                           SimFloat16(RawbitsToFloat16(                       \
+                               static_cast<uint16_t>(src.Uint(vform, 1)))))); \
+      dst.SetUint(vform, 0, Float16ToRawbits(result));                        \
+    } else if (vform == kFormatS) {                                           \
+      float result = OP(src.Float<float>(0), src.Float<float>(1));            \
+      dst.SetFloat(0, result);                                                \
+    } else {                                                                  \
+      VIXL_ASSERT(vform == kFormatD);                                         \
+      double result = OP(src.Float<double>(0), src.Float<double>(1));         \
+      dst.SetFloat(0, result);                                                \
+    }                                                                         \
+    dst.ClearForWrite(vform);                                                 \
+    return dst;                                                               \
   }
 NEON_FPPAIRWISE_LIST(DEFINE_NEON_FP_PAIR_OP)
 #undef DEFINE_NEON_FP_PAIR_OP
@@ -5833,7 +5835,8 @@ LogicVRegister Simulator::frint(VectorFormat vform,
   } else if (LaneSizeInBitsFromFormat(vform) == kSRegSize) {
     for (int i = 0; i < LaneCountFromFormat(vform); i++) {
       float input = src.Float<float>(i);
-      float rounded = FPRoundInt(input, rounding_mode, frint_mode);
+      float rounded =
+          static_cast<float>(FPRoundInt(input, rounding_mode, frint_mode));
 
       if (inexact_exception && !IsNaN(input) && (input != rounded)) {
         FPProcessException();
@@ -6143,9 +6146,9 @@ T Simulator::FPRecipSqrtEstimate(T op) {
     return FPProcessNaN(op);
   } else if (op == 0.0) {
     if (copysign(1.0, op) < 0.0) {
-      return kFP64NegativeInfinity;
+      return T(kFP64NegativeInfinity);
     } else {
-      return kFP64PositiveInfinity;
+      return T(kFP64PositiveInfinity);
     }
   } else if (copysign(1.0, op) < 0.0) {
     FPProcessException();
@@ -6156,11 +6159,11 @@ T Simulator::FPRecipSqrtEstimate(T op) {
     uint64_t fraction;
     int exp, result_exp;
 
-    if (IsFloat16<T>()) {
+    if constexpr (IsFloat16<T>()) {
       exp = Float16Exp(op);
       fraction = Float16Mantissa(op);
       fraction <<= 42;
-    } else if (IsFloat32<T>()) {
+    } else if constexpr (IsFloat32<T>()) {
       exp = FloatExp(op);
       fraction = FloatMantissa(op);
       fraction <<= 29;
@@ -6185,9 +6188,9 @@ T Simulator::FPRecipSqrtEstimate(T op) {
       scaled = DoublePack(0, 1021, Bits(fraction, 51, 44) << 44);
     }
 
-    if (IsFloat16<T>()) {
+    if constexpr (IsFloat16<T>()) {
       result_exp = (44 - exp) / 2;
-    } else if (IsFloat32<T>()) {
+    } else if constexpr (IsFloat32<T>()) {
       result_exp = (380 - exp) / 2;
     } else {
       VIXL_ASSERT(IsFloat64<T>());
@@ -6196,11 +6199,11 @@ T Simulator::FPRecipSqrtEstimate(T op) {
 
     uint64_t estimate = DoubleToRawbits(recip_sqrt_estimate(scaled));
 
-    if (IsFloat16<T>()) {
+    if constexpr (IsFloat16<T>()) {
       uint16_t exp_bits = static_cast<uint16_t>(Bits(result_exp, 4, 0));
       uint16_t est_bits = static_cast<uint16_t>(Bits(estimate, 51, 42));
       return Float16Pack(0, exp_bits, est_bits);
-    } else if (IsFloat32<T>()) {
+    } else if constexpr (IsFloat32<T>()) {
       uint32_t exp_bits = static_cast<uint32_t>(Bits(result_exp, 7, 0));
       uint32_t est_bits = static_cast<uint32_t>(Bits(estimate, 51, 29));
       return FloatPack(0, exp_bits, est_bits);
@@ -6240,9 +6243,9 @@ template <typename T>
 T Simulator::FPRecipEstimate(T op, FPRounding rounding) {
   uint32_t sign;
 
-  if (IsFloat16<T>()) {
+  if constexpr (IsFloat16<T>()) {
     sign = Float16Sign(op);
-  } else if (IsFloat32<T>()) {
+  } else if constexpr (IsFloat32<T>()) {
     sign = FloatSign(op);
   } else {
     VIXL_ASSERT(IsFloat64<T>());
@@ -6252,10 +6255,10 @@ T Simulator::FPRecipEstimate(T op, FPRounding rounding) {
   if (IsNaN(op)) {
     return FPProcessNaN(op);
   } else if (IsInf(op)) {
-    return (sign == 1) ? -0.0 : 0.0;
+    return (sign == 1) ? T(-0.0) : T(0.0);
   } else if (op == 0.0) {
     FPProcessException();  // FPExc_DivideByZero exception.
-    return (sign == 1) ? kFP64NegativeInfinity : kFP64PositiveInfinity;
+    return (sign == 1) ? T(kFP64NegativeInfinity) : T(kFP64PositiveInfinity);
   } else if ((IsFloat16<T>() && (std::fabs(op) < std::pow(2.0, -16.0))) ||
              (IsFloat32<T>() && (std::fabs(op) < std::pow(2.0, -128.0))) ||
              (IsFloat64<T>() && (std::fabs(op) < std::pow(2.0, -1024.0)))) {
@@ -6278,12 +6281,12 @@ T Simulator::FPRecipEstimate(T op, FPRounding rounding) {
     }
     FPProcessException();  // FPExc_Overflow and FPExc_Inexact.
     if (overflow_to_inf) {
-      return (sign == 1) ? kFP64NegativeInfinity : kFP64PositiveInfinity;
+      return (sign == 1) ? T(kFP64NegativeInfinity) : T(kFP64PositiveInfinity);
     } else {
       // Return FPMaxNormal(sign).
-      if (IsFloat16<T>()) {
+      if constexpr (IsFloat16<T>()) {
         return Float16Pack(sign, 0x1f, 0x3ff);
-      } else if (IsFloat32<T>()) {
+      } else if constexpr (IsFloat32<T>()) {
         return FloatPack(sign, 0xfe, 0x07fffff);
       } else {
         VIXL_ASSERT(IsFloat64<T>());
@@ -6294,12 +6297,12 @@ T Simulator::FPRecipEstimate(T op, FPRounding rounding) {
     uint64_t fraction;
     int exp, result_exp;
 
-    if (IsFloat16<T>()) {
+    if constexpr (IsFloat16<T>()) {
       sign = Float16Sign(op);
       exp = Float16Exp(op);
       fraction = Float16Mantissa(op);
       fraction <<= 42;
-    } else if (IsFloat32<T>()) {
+    } else if constexpr (IsFloat32<T>()) {
       sign = FloatSign(op);
       exp = FloatExp(op);
       fraction = FloatMantissa(op);
@@ -6322,9 +6325,9 @@ T Simulator::FPRecipEstimate(T op, FPRounding rounding) {
 
     double scaled = DoublePack(0, 1022, Bits(fraction, 51, 44) << 44);
 
-    if (IsFloat16<T>()) {
+    if constexpr (IsFloat16<T>()) {
       result_exp = (29 - exp);  // In range 29-30 = -1 to 29+1 = 30.
-    } else if (IsFloat32<T>()) {
+    } else if constexpr (IsFloat32<T>()) {
       result_exp = (253 - exp);  // In range 253-254 = -1 to 253+1 = 254.
     } else {
       VIXL_ASSERT(IsFloat64<T>());
@@ -6340,11 +6343,11 @@ T Simulator::FPRecipEstimate(T op, FPRounding rounding) {
       fraction = (UINT64_C(1) << 50) | Bits(fraction, 51, 2);
       result_exp = 0;
     }
-    if (IsFloat16<T>()) {
+    if constexpr (IsFloat16<T>()) {
       uint16_t exp_bits = static_cast<uint16_t>(Bits(result_exp, 4, 0));
       uint16_t frac_bits = static_cast<uint16_t>(Bits(fraction, 51, 42));
       return Float16Pack(sign, exp_bits, frac_bits);
-    } else if (IsFloat32<T>()) {
+    } else if constexpr (IsFloat32<T>()) {
       uint32_t exp_bits = static_cast<uint32_t>(Bits(result_exp, 7, 0));
       uint32_t frac_bits = static_cast<uint32_t>(Bits(fraction, 51, 29));
       return FloatPack(sign, exp_bits, frac_bits);
@@ -6490,12 +6493,12 @@ LogicVRegister Simulator::frecpx(VectorFormat vform,
     } else {
       int exp;
       uint32_t sign;
-      if (IsFloat16<T>()) {
+      if constexpr (IsFloat16<T>()) {
         sign = Float16Sign(op);
         exp = Float16Exp(op);
         exp = (exp == 0) ? (0x1F - 1) : static_cast<int>(Bits(~exp, 4, 0));
         result = Float16Pack(sign, exp, 0);
-      } else if (IsFloat32<T>()) {
+      } else if constexpr (IsFloat32<T>()) {
         sign = FloatSign(op);
         exp = FloatExp(op);
         exp = (exp == 0) ? (0xFF - 1) : static_cast<int>(Bits(~exp, 7, 0));
@@ -6799,18 +6802,21 @@ LogicVRegister Simulator::fexpa(VectorFormat vform,
 
   if (lane_size == kHRegSize) {
     index_highbit = 4;
-    VIXL_ASSERT(ArrayLength(fexpa_coeff16) == (1U << (index_highbit + 1)));
+    VIXL_ASSERT(ArrayLength(fexpa_coeff16) ==
+                (uint64_t{1} << (index_highbit + 1)));
     fexpa_coeff = fexpa_coeff16;
     op_highbit = 9;
     op_shift = 10;
   } else if (lane_size == kSRegSize) {
-    VIXL_ASSERT(ArrayLength(fexpa_coeff32) == (1U << (index_highbit + 1)));
+    VIXL_ASSERT(ArrayLength(fexpa_coeff32) ==
+                (uint64_t{1} << (index_highbit + 1)));
     fexpa_coeff = fexpa_coeff32;
     op_highbit = 13;
     op_shift = 23;
   } else {
     VIXL_ASSERT(lane_size == kDRegSize);
-    VIXL_ASSERT(ArrayLength(fexpa_coeff64) == (1U << (index_highbit + 1)));
+    VIXL_ASSERT(ArrayLength(fexpa_coeff64) ==
+                (uint64_t{1} << (index_highbit + 1)));
     fexpa_coeff = fexpa_coeff64;
     op_highbit = 16;
     op_shift = 52;
@@ -8240,10 +8246,10 @@ static uint8_t GalMul(int table, uint64_t x) {
       return ffmul0e[x];
     case 0:
       // Case 0 indicates no table lookup, used for some forward mix stages.
-      return x;
+      return static_cast<uint8_t>(x);
     default:
       VIXL_UNREACHABLE();
-      return x;
+      return static_cast<uint8_t>(x);
   }
 }
 

--- a/src/aarch64/pointer-auth-aarch64.cc
+++ b/src/aarch64/pointer-auth-aarch64.cc
@@ -151,7 +151,7 @@ uint64_t Simulator::AuthPAC(uint64_t ptr,
 
   uint64_t pac = ComputePAC(original_ptr, context, key);
 
-  uint64_t error_code = 1 << key.number;
+  uint64_t error_code = uint64_t{1} << key.number;
   if ((pac & pac_mask) == (ptr & pac_mask)) {
     return original_ptr;
   } else {

--- a/src/utils-vixl.h
+++ b/src/utils-vixl.h
@@ -559,13 +559,14 @@ inline T SignExtend(T val, int size_in_bits) {
 template <typename T>
 T ReverseBytes(T value, int block_bytes_log2) {
   VIXL_ASSERT((sizeof(value) == 4) || (sizeof(value) == 8));
-  VIXL_ASSERT((1U << block_bytes_log2) <= sizeof(value));
+  VIXL_ASSERT((uint64_t{1} << block_bytes_log2) <= sizeof(value));
   // Split the 64-bit value into an 8-bit array, where b[0] is the least
   // significant byte, and b[7] is the most significant.
   uint8_t bytes[8];
   uint64_t mask = UINT64_C(0xff00000000000000);
   for (int i = 7; i >= 0; i--) {
-    bytes[i] = (static_cast<uint64_t>(value) & mask) >> (i * 8);
+    bytes[i] =
+        static_cast<uint8_t>((static_cast<uint64_t>(value) & mask) >> (i * 8));
     mask >>= 8;
   }
 


### PR DESCRIPTION
Use `MemoryBarrier()` in place of `__sync_synchronize()` on MSVC
I had opted against using `std::atomic_thread_fence` due to the following note on [cppreference.com](https://en.cppreference.com/w/cpp/atomic/atomic_thread_fence) "Note however, that at least one atomic operation is required to set up the synchronization", yet our reads/writes seem to be done via `memcpy`.
While this [Stack overflow answer](https://stackoverflow.com/a/75773044/9109981) suggests the lack of `std::atomic` usage won't make a difference, I've opted to play it safe.
If desired, I can instead switch this to use `std::atomic_thread_fence`

Use `VirtualQuery` in place of posix pipes on Windows.
I can instead swap with with the windows specific `_pipe`/`_read`/`_write` api if you would prefer this code to more closely match posix platforms.

Only include `Simulator::Mmap()`/`Simulator::Mumap()` when the define `__linux__` is present
This aligns with VIXL_CODE_BUFFER_MMAP (added in scons)
`VIXL_HAS_SIMULATED_MMAP` is defined when `Simulator::Mmap()`/`Simulator::Mumap()` are present.

Add MSVC to the list of compilers have runtime call support
I'll note that `MetaDataDepot::BranchInterception<R, P...>::operator()` fails to compile without runtime call support, as it doesn't check for the relevant define, does this warrant a separate issue?
I suspect that the checks for runtime call support are redundant given vixl requires C++17.

Address various warnings a `/W3`
These mostly consisted of warning involving narrowing conversions, or the result of 32bit shifts being converted to 64bit values