### PR TITLE
[aarch32] Make RawLiteral (and therefore Literal) movable

### DIFF
--- a/src/aarch32/location-aarch32.h
+++ b/src/aarch32/location-aarch32.h
@@ -71,6 +71,8 @@ class Location : public LocationBase<int32_t> {
 #endif
   }
 
+  Location(Location&&) = default; // movable
+
   bool IsReferenced() const { return referenced_; }
 
  private:
@@ -318,6 +320,12 @@ class RawLiteral : public Location {
         addr_(addr),
         manually_placed_(false),
         deletion_policy_(deletion_policy) {}
+
+  // noncopyable to avoid one instruction appearing to refer to two or more literals
+  RawLiteral(const RawLiteral&) = delete;
+
+  RawLiteral(RawLiteral &&) = default; // movable
+
   const void* GetDataAddress() const { return addr_; }
   int GetSize() const { return GetPoolObjectSizeInBytes(); }
 

--- a/src/invalset-vixl.h
+++ b/src/invalset-vixl.h
@@ -1,4 +1,3 @@
-// Copyright 2015, VIXL authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -91,6 +90,7 @@ class InvalSet {
  public:
   InvalSet();
   ~InvalSet() VIXL_NEGATIVE_TESTING_ALLOW_EXCEPTION;
+  InvalSet(InvalSet&&);  // movable
 
   static const size_t kNPreallocatedElements = N_PREALLOCATED_ELEMENTS;
   static const KeyType kInvalidKey = INVALID_KEY;
@@ -325,6 +325,27 @@ InvalSet<TEMPLATE_INVALSET_P_DEF>::InvalSet()
 #endif
 }
 
+template <TEMPLATE_INVALSET_P_DECL>
+InvalSet<TEMPLATE_INVALSET_P_DEF>::InvalSet(InvalSet&& other)
+    : valid_cached_min_(false), sorted_(true), size_(0), vector_(NULL) {
+  VIXL_ASSERT(other.monitor() == 0);
+  if (this != &other) {
+    sorted_ = other.sorted_;
+    size_ = other.size_;
+#ifdef VIXL_DEBUG
+    monitor_ = 0;
+#endif
+    if (other.IsUsingVector()) {
+      vector_ = other.vector_;
+      other.vector_ = NULL;
+    } else {
+      std::move(other.preallocated_,
+                other.preallocated_ + other.size_,
+                preallocated_);
+    }
+    other.clear();
+  }
+}
 
 template <TEMPLATE_INVALSET_P_DECL>
 InvalSet<TEMPLATE_INVALSET_P_DEF>::~InvalSet()

--- a/test/test-invalset.cc
+++ b/test/test-invalset.cc
@@ -397,5 +397,27 @@ TEST(stl_forward_iterator) {
 #endif
 }
 
+TEST(move) {
+  TestSet set1;
+
+  set1.insert(Obj(-123, 456));
+  set1.insert(Obj(2718, 2871828));
+
+  TestSet set2(std::move(set1));
+  VIXL_CHECK(set1.empty());
+  VIXL_CHECK(set2.size() == 2);
+  VIXL_CHECK(set2.GetMinElement() == Obj(-123, 456));
+
+  // Test with more elements.
+  for (unsigned i = 0; i < 4 * kNPreallocatedElements; i++) {
+    set2.insert(Obj(i, -1));
+  }
+
+  TestSet set3(std::move(set2));
+  VIXL_CHECK(set2.empty());
+  VIXL_CHECK(set3.size() == 2 + 4 * kNPreallocatedElements);
+  VIXL_CHECK(set3.GetMinElement() == Obj(-123, 456));
+}
+
 
 }  // namespace vixl


### PR DESCRIPTION
Make RawLiteral (and therefore Literal) noncopyable but movable.

This is in order to prevent one instruction from appearing to refer to two literals.

Moving is permitted as it does not cause the same problem, and can be useful to allow containers of Literal