### PR TITLE
Fix backward branch veneers

### DIFF
--- a/src/aarch64/macro-assembler-aarch64.h
+++ b/src/aarch64/macro-assembler-aarch64.h
@@ -8249,9 +8249,10 @@ class MacroAssembler : public Assembler, public MacroAssemblerInterface {
       UseScratchRegisterScope* scratch_scope);
 
   bool LabelIsOutOfRange(Label* label, ImmBranchType branch_type) {
+    int64_t offset = label->GetLocation() - GetCursorOffset();
+    VIXL_ASSERT(IsMultiple(offset, kInstructionSize));
     return !Instruction::IsValidImmPCOffset(branch_type,
-                                            label->GetLocation() -
-                                                GetCursorOffset());
+                                            offset / kInstructionSize);
   }
 
   void ConfigureSimulatorCPUFeaturesHelper(const CPUFeatures& features,


### PR DESCRIPTION
Veneers were applied to backward branches too early, using only a quarter of the range available for the branch. This was caused by confusion over the units the range function expects; it accepts an offset in instructions.

Correct this and test veneers are applied only beyond the limit of the branch range.