### PR TITLE
Fix format specifiers in the simulator

### DIFF
--- a/src/aarch64/simulator-aarch64.cc
+++ b/src/aarch64/simulator-aarch64.cc
@@ -1836,7 +1836,7 @@ void Simulator::PrintSystemRegister(SystemRegister id) {
 void Simulator::PrintGCS(bool is_push, uint64_t addr, size_t entry) {
   const char* arrow = is_push ? "<-" : "->";
   fprintf(stream_,
-          "# %sgcs0x%04" PRIx64 "[%" PRIu64 "]: %s %s 0x%016" PRIxPTR "\n",
+          "# %sgcs0x%04" PRIx64 "[%zx]: %s %s 0x%016" PRIx64 "\n",
           clr_flag_name,
           gcs_,
           entry,

--- a/src/aarch64/simulator-aarch64.h
+++ b/src/aarch64/simulator-aarch64.h
@@ -2577,7 +2577,7 @@ class Simulator : public DecoderVisitor {
   }
   void PrintWriteU64(uint64_t x, uintptr_t address) {
     fprintf(stream_,
-            "#      0x%016lx -> %s0x%016" PRIxPTR "%s\n",
+            "#      0x%016" PRIx64 " -> %s0x%016" PRIxPTR "%s\n",
             x,
             clr_memory_address,
             address,


### PR DESCRIPTION
Fix format specifiers in the simulator to match the given arguments. This will also silence -Wformat warnings when building with 32 bit flags.